### PR TITLE
Fixes for brooklyn direct access

### DIFF
--- a/alien4cloud-core/src/main/java/alien4cloud/topology/TopologyService.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/topology/TopologyService.java
@@ -452,7 +452,7 @@ public class TopologyService {
         velocityCtx.put("template_version", "1.0.0-SNAPSHOT");
         User loggedUser = AuthorizationUtil.getCurrentUser();
         velocityCtx.put("template_author", loggedUser != null ? loggedUser.getUsername() : null);
-        if (topology.getDelegateType().equals(Application.class.getSimpleName().toLowerCase())) {
+        if (Application.class.getSimpleName().toLowerCase().equals(topology.getDelegateType())) {
             String applicationId = topology.getDelegateId();
             Application application = appService.getOrFail(applicationId);
             velocityCtx.put("template_name", application.getName());
@@ -461,7 +461,7 @@ public class TopologyService {
             if (version != null) {
                 velocityCtx.put("template_version", version.getVersion());
             }
-        } else if (topology.getDelegateType().equals(TopologyTemplate.class.getSimpleName().toLowerCase())) {
+        } else if (TopologyTemplate.class.getSimpleName().toLowerCase().equals(topology.getDelegateType())) {
             String topologyTemplateId = topology.getDelegateId();
             TopologyTemplate template = getOrFailTopologyTemplate(topologyTemplateId);
             velocityCtx.put("template_name", template.getName());

--- a/alien4cloud-core/src/main/java/alien4cloud/tosca/ArchiveParser.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/tosca/ArchiveParser.java
@@ -124,9 +124,11 @@ public class ArchiveParser {
                 return toscaParser.parseFile(visitor.getDefinitionFiles().get(0));
             }
             throw new ParsingException("Archive", new ParsingError(ErrorCode.SINGLE_DEFINITION_SUPPORTED,
-                    "Alien only supports archives with a single root definition.", null, null, null, String.valueOf(visitor.getDefinitionFiles().size())));
+                    "Alien only supports archives with a single root definition.", null, null, null, 
+                    "Matching file count in root of "+csarFS+": "+visitor.getDefinitionFiles().size()));
         } catch (IOException e) {
-            throw new ParsingException("Archive", new ParsingError(ErrorCode.FAILED_TO_READ_FILE, "Failed to list root definitions", null, null, null, null));
+            throw new ParsingException("Archive", new ParsingError(ErrorCode.FAILED_TO_READ_FILE, "Failed to list root definitions", null, null, null, 
+                "Error reading "+csarFS+": "+e));
         }
     }
 }

--- a/alien4cloud-core/src/main/java/alien4cloud/tosca/ArchiveUploadService.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/tosca/ArchiveUploadService.java
@@ -54,7 +54,7 @@ public class ArchiveUploadService {
     private TopologyTemplateVersionService topologyTemplateVersionService;
 
     /**
-     * Upload a TOSCA archive and index it's components.
+     * Upload a TOSCA archive and index its components.
      * 
      * @param path The archive path.
      * @return The Csar object from the parsing.

--- a/alien4cloud-core/src/main/java/alien4cloud/tosca/parser/ParsingError.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/tosca/parser/ParsingError.java
@@ -57,6 +57,6 @@ public class ParsingError {
 
     @Override
     public String toString() {
-        return "Context: " + context + "\nProblem: " + problem + "\nNote: " + note + "\nStart: " + startMark + "\nEnd  : " + endMark;
+        return "Context: " + context + "\nProblem: " + problem + "\nNote: " + note + "\nStart: " + startMark + "\nEnd  : " + endMark + "\nLevel: " + errorLevel + "\nCode : " + errorCode;
     }
 }

--- a/alien4cloud-core/src/main/java/alien4cloud/tosca/parser/impl/advanced/DerivedFromParser.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/tosca/parser/impl/advanced/DerivedFromParser.java
@@ -51,7 +51,7 @@ public abstract class DerivedFromParser extends DefaultDeferredParser<List<Strin
         if (parent == null) {
             context.getParsingErrors().add(
                     new ParsingError(ErrorCode.TYPE_NOT_FOUND, "Derived_from type not found", node.getStartMark(),
-                            "The type specified as parent is not found neither in the archive or it's dependencies.", node.getEndMark(), valueAsString));
+                            "The type specified as parent is not found neither in the archive or its dependencies.", node.getEndMark(), valueAsString));
             return null;
         }
         List<String> derivedFrom;

--- a/alien4cloud-core/src/main/java/alien4cloud/tosca/parser/impl/advanced/NodeTemplateChecker.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/tosca/parser/impl/advanced/NodeTemplateChecker.java
@@ -60,7 +60,7 @@ public class NodeTemplateChecker implements IChecker<NodeTemplate> {
             // node type can't be found neither in archive or in dependencies
             context.getParsingErrors()
                     .add(new ParsingError(ErrorCode.TYPE_NOT_FOUND, "Derived_from type not found", node.getStartMark(),
-                            "The type specified for a node_template is not found neither in the archive or it's dependencies.", node.getEndMark(), nodeTypeName));
+                            "The type specified for a node_template is not found neither in the archive nor its dependencies.", node.getEndMark(), nodeTypeName));
             return;
         }
         IToscaElementFinder toscaElementFinder = new IToscaElementFinder() {

--- a/alien4cloud-core/src/main/java/alien4cloud/tosca/parser/impl/advanced/RelationshipTemplatesParser.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/tosca/parser/impl/advanced/RelationshipTemplatesParser.java
@@ -175,7 +175,7 @@ public class RelationshipTemplatesParser extends DefaultDeferredParser<Map<Strin
         ArchiveRoot archiveRoot = (ArchiveRoot) context.getRoot().getWrappedInstance();
         IndexedNodeType indexedNodeType = ToscaParsingUtil.getNodeTypeFromArchiveOrDependencies(nodeTemplate.getType(), archiveRoot, searchService);
         if (indexedNodeType == null) {
-            // the note type is null if not found in archive or dep, the error is already raised
+            // the node type is null if not found in archive or dep, the error is already raised
             return null;
         }
         RequirementDefinition rd = getRequirementDefinitionByName(indexedNodeType, toscaRequirementName);
@@ -184,7 +184,7 @@ public class RelationshipTemplatesParser extends DefaultDeferredParser<Map<Strin
                     new ParsingError(ErrorCode.REQUIREMENT_NOT_FOUND, null, node.getStartMark(), null, node.getEndMark(), toscaRequirementName));
             return null;
         }
-        // the relationship template type is take from 'relationship' node or requirement definition
+        // the relationship template type is taken from 'relationship' node or requirement definition
         String relationshipTypeName = (relationshipType != null) ? relationshipType : rd.getRelationshipType();
         // ex: host
         relationshipTemplate.setRequirementName(toscaRequirementName);

--- a/alien4cloud-core/src/main/java/alien4cloud/tosca/parser/impl/advanced/TopologyChecker.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/tosca/parser/impl/advanced/TopologyChecker.java
@@ -34,6 +34,7 @@ import alien4cloud.tosca.properties.constraints.exception.ConstraintValueDoNotMa
 import alien4cloud.tosca.properties.constraints.exception.ConstraintViolationException;
 import alien4cloud.utils.services.ConstraintPropertyService;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
@@ -78,6 +79,7 @@ public class TopologyChecker implements IChecker<Topology> {
         if (dependencies != null) {
             instance.setDependencies(dependencies);
         }
+        
         // here we need to check that the group members really exist
         if (instance.getGroups() != null && !instance.getGroups().isEmpty()) {
             int i = 0;
@@ -184,7 +186,7 @@ public class TopologyChecker implements IChecker<Topology> {
         for (int i = 0; i < hierarchyList.size() - 1; i++) {
             T from = hierarchyList.get(i);
             T to = hierarchyList.get(i + 1);
-            if (to.getArchiveName().equals(archiveRoot.getArchive().getName()) && to.getArchiveVersion().equals(archiveRoot.getArchive().getVersion())) {
+            if (Objects.equal(to.getArchiveName(), archiveRoot.getArchive()) && Objects.equal(to.getArchiveVersion(), archiveRoot.getArchive().getVersion())) {
                 // we only merge element that come with current archive (the one we are parsing).
                 // by this way, we don't remerge existing elements
                 IndexedModelUtils.mergeInheritableIndex(from, to);


### PR DESCRIPTION
Guard against some NPE's which can occur during parses, and some more detailed error messages in places where I got stuck.