### PR TITLE
support interfaces on node templates

### DIFF
--- a/alien4cloud-core/src/main/java/alien4cloud/model/topology/NodeTemplate.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/model/topology/NodeTemplate.java
@@ -6,8 +6,10 @@ import java.util.Set;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
 import alien4cloud.model.components.AbstractPropertyValue;
 import alien4cloud.model.components.DeploymentArtifact;
+import alien4cloud.model.components.Interface;
 import alien4cloud.utils.jackson.ConditionalAttributes;
 import alien4cloud.utils.jackson.ConditionalOnAttribute;
 import alien4cloud.utils.jackson.JSonMapEntryArrayDeSerializer;
@@ -63,6 +65,11 @@ public class NodeTemplate extends AbstractTemplate {
     @JsonSerialize(using = JSonMapEntryArraySerializer.class)
     private Map<String, Capability> capabilities;
 
+    @ConditionalOnAttribute(ConditionalAttributes.REST)
+    @JsonDeserialize(using = JSonMapEntryArrayDeSerializer.class)
+    @JsonSerialize(using = JSonMapEntryArraySerializer.class)
+    private Map<String, Interface> interfaces;
+    
     /**
      * The {@link NodeGroup}s this template is member of.
      */
@@ -70,7 +77,7 @@ public class NodeTemplate extends AbstractTemplate {
 
     public NodeTemplate(String type, Map<String, AbstractPropertyValue> properties, Map<String, String> attributes,
             Map<String, RelationshipTemplate> relationships, Map<String, Requirement> requirements, Map<String, Capability> capabilities,
-            Map<String, DeploymentArtifact> artifacts) {
+            Map<String, Interface> interfaces, Map<String, DeploymentArtifact> artifacts) {
         this.setType(type);
         this.setProperties(properties);
         this.setArtifacts(artifacts);
@@ -78,5 +85,6 @@ public class NodeTemplate extends AbstractTemplate {
         this.relationships = relationships;
         this.requirements = requirements;
         this.capabilities = capabilities;
+        this.interfaces = interfaces;
     }
 }

--- a/alien4cloud-core/src/main/resources/tosca-simple-profile-wd03-mapping.yml
+++ b/alien4cloud-core/src/main/resources/tosca-simple-profile-wd03-mapping.yml
@@ -116,6 +116,9 @@
     reference: void
     deferred: true
     type: nodetemplate_capabilities_type
+  interfaces:
+    reference: interfaces
+    type: interfaces
   artifacts:
     map: artifacts
     type: template_deployment_artifact

--- a/alien4cloud-core/src/test/java/alien4cloud/component/dao/NodeTypeScoreServiceTest.java
+++ b/alien4cloud-core/src/test/java/alien4cloud/component/dao/NodeTypeScoreServiceTest.java
@@ -61,7 +61,7 @@ public class NodeTypeScoreServiceTest {
         Topology topology = new Topology();
         topology.setId("topology");
         topology.setNodeTemplates(MapUtil.newHashMap(new String[] { "isengard" }, new NodeTemplate[] { new NodeTemplate(indexedNodeType.getId(), null, null,
-                null, null, null, null) }));
+                null, null, null, null, null) }));
         dao.save(topology);
 
         indexedNodeType.setElementId("osgiliath");

--- a/alien4cloud-core/src/test/java/alien4cloud/paas/ha/AvailabilityZoneAllocatorTest.java
+++ b/alien4cloud-core/src/test/java/alien4cloud/paas/ha/AvailabilityZoneAllocatorTest.java
@@ -73,7 +73,7 @@ public class AvailabilityZoneAllocatorTest {
         Map<String, PaaSNodeTemplate> volumes = Maps.newHashMap();
         for (PaaSNodeTemplate compute : computes) {
             NodeTemplate wrappedVolume = new NodeTemplate(NormativeBlockStorageConstants.BLOCKSTORAGE_TYPE, Maps.<String, AbstractPropertyValue> newHashMap(),
-                    null, null, null, null, null);
+                    null, null, null, null, null, null);
             wrappedVolume.getProperties().put(NormativeBlockStorageConstants.VOLUME_ID, new ScalarPropertyValue(zones.iterator().next().getId() + "/abcde"));
             PaaSNodeTemplate volume = new PaaSNodeTemplate("volume_" + compute.getId(), wrappedVolume);
             volume.setParent(compute);


### PR DESCRIPTION
As per A.7.3.2 in WD3 it is permitted to define or override `interfaces` in the definition of a node template.  This adds support for this, coming from YAML, and accessible via `NodeTemplate.getInterfaces()`.