### PR TITLE
Define a generic policy

### DIFF
--- a/alien4cloud-core/src/main/java/alien4cloud/json/deserializer/AbstractFieldValueDiscriminatorPolymorphicDeserializer.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/json/deserializer/AbstractFieldValueDiscriminatorPolymorphicDeserializer.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,6 +34,10 @@ public class AbstractFieldValueDiscriminatorPolymorphicDeserializer<T> extends S
     public T deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
         ObjectMapper mapper = (ObjectMapper) jp.getCodec();
         ObjectNode root = mapper.readTree(jp);
+        return deserializeAfterRead(jp, ctxt, mapper, root);
+    }
+
+    protected T deserializeAfterRead(JsonParser jp, DeserializationContext ctxt, ObjectMapper mapper, ObjectNode root) throws JsonProcessingException {
         Class<? extends T> parameterClass = null;
         Iterator<Map.Entry<String, JsonNode>> elementsIterator = root.fields();
         while (elementsIterator.hasNext()) {

--- a/alien4cloud-core/src/main/java/alien4cloud/json/deserializer/PolicyDeserializer.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/json/deserializer/PolicyDeserializer.java
@@ -1,6 +1,16 @@
 package alien4cloud.json.deserializer;
 
+import java.io.IOException;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import alien4cloud.model.topology.AbstractPolicy;
+import alien4cloud.model.topology.GenericPolicy;
 import alien4cloud.model.topology.HaPolicy;
 
 /**
@@ -12,4 +22,15 @@ public class PolicyDeserializer extends AbstractFieldValueDiscriminatorPolymorph
         addToRegistry(HaPolicy.HA_POLICY, HaPolicy.class);
     }
 
+    @Override
+    protected AbstractPolicy deserializeAfterRead(JsonParser jp, DeserializationContext ctxt, ObjectMapper mapper, ObjectNode root) throws JsonProcessingException {
+        AbstractPolicy result = super.deserializeAfterRead(jp, ctxt, mapper, root);
+        if (result!=null) return result;
+
+        // treat anything else as generic policy
+        // all data is stored in the field data so extract that
+        Map data = mapper.treeToValue(root, Map.class);
+        if (data.containsKey("data")) data = (Map) data.get("data");
+        return new GenericPolicy( data );
+    }
 }

--- a/alien4cloud-core/src/main/java/alien4cloud/model/topology/AbstractPolicy.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/model/topology/AbstractPolicy.java
@@ -13,8 +13,7 @@ public abstract class AbstractPolicy {
 
     public abstract String getType();
 
-    public void setType(String type) {
-        // here only for JSON deserialization
-    }
+    // needed for JSON deserialization ?
+    public abstract void setType(String type);
 
 }

--- a/alien4cloud-core/src/main/java/alien4cloud/model/topology/GenericPolicy.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/model/topology/GenericPolicy.java
@@ -1,0 +1,23 @@
+package alien4cloud.model.topology;
+
+import java.util.Map;
+
+import lombok.Getter;
+import lombok.Setter;
+import alien4cloud.tosca.parser.impl.advanced.GroupPolicyParser;
+
+/** For any unknown policy, let's record its data; maybe an external system can make use of it. */
+@Getter
+@Setter
+public class GenericPolicy extends AbstractPolicy {
+
+    public GenericPolicy(Map<String,?> parsedData) {
+        setName((String)parsedData.get(GroupPolicyParser.NAME));
+        setType((String)parsedData.get(GroupPolicyParser.TYPE));
+        data = parsedData;
+    }
+    
+    private String type;
+    private Map<String, ?> data;
+
+}

--- a/alien4cloud-core/src/main/java/alien4cloud/model/topology/GenericPolicy.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/model/topology/GenericPolicy.java
@@ -3,12 +3,14 @@ package alien4cloud.model.topology;
 import java.util.Map;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import alien4cloud.tosca.parser.impl.advanced.GroupPolicyParser;
 
 /** For any unknown policy, let's record its data; maybe an external system can make use of it. */
 @Getter
 @Setter
+@NoArgsConstructor
 public class GenericPolicy extends AbstractPolicy {
 
     public GenericPolicy(Map<String,?> parsedData) {

--- a/alien4cloud-core/src/main/java/alien4cloud/model/topology/HaPolicy.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/model/topology/HaPolicy.java
@@ -2,8 +2,10 @@ package alien4cloud.model.topology;
 
 import java.util.Map;
 
+import lombok.NoArgsConstructor;
 import alien4cloud.tosca.parser.impl.advanced.GroupPolicyParser;
 
+@NoArgsConstructor
 public class HaPolicy extends AbstractPolicy {
 
     public static final String HA_POLICY = "tosca.policy.ha";

--- a/alien4cloud-core/src/main/java/alien4cloud/model/topology/HaPolicy.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/model/topology/HaPolicy.java
@@ -1,12 +1,26 @@
 package alien4cloud.model.topology;
 
+import java.util.Map;
+
+import alien4cloud.tosca.parser.impl.advanced.GroupPolicyParser;
+
 public class HaPolicy extends AbstractPolicy {
 
     public static final String HA_POLICY = "tosca.policy.ha";
 
+    public HaPolicy(Map<String, Object> nodeMap) {
+        setName((String) nodeMap.get(GroupPolicyParser.NAME));
+        // is there any other data in nodeMap we care about?
+    }
+
     @Override
     public String getType() {
         return HA_POLICY;
+    }
+    
+    @Override
+    public void setType(String type) {
+        // for json serialization
     }
 
 }

--- a/alien4cloud-core/src/main/java/alien4cloud/tosca/parser/ParsingError.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/tosca/parser/ParsingError.java
@@ -2,6 +2,7 @@ package alien4cloud.tosca.parser;
 
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
 import org.yaml.snakeyaml.error.Mark;
 import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -13,6 +14,7 @@ import alien4cloud.tosca.parser.impl.ErrorCode;
  */
 @Getter
 @Setter
+@Slf4j
 public class ParsingError {
     private ParsingErrorLevel errorLevel;
     private ErrorCode errorCode;
@@ -33,26 +35,18 @@ public class ParsingError {
         this.problem = problem;
         this.endMark = endMark == null ? null : new SimpleMark(endMark);
         this.note = note;
+        if (errorLevel == ParsingErrorLevel.ERROR) {
+            // this is a handy place to put a breakpoint if you want to know where errors are coming from
+            log.debug("Error found during parse, rethrowing:\n"+this);
+        }
     }
 
     public ParsingError(ErrorCode errorCode, String context, Mark startMark, String problem, Mark endMark, String note) {
-        this.errorLevel = ParsingErrorLevel.ERROR;
-        this.errorCode = errorCode;
-        this.context = context;
-        this.startMark = startMark == null ? null : new SimpleMark(startMark);
-        this.problem = problem;
-        this.endMark = endMark == null ? null : new SimpleMark(endMark);
-        this.note = note;
+        this(ParsingErrorLevel.ERROR, errorCode, context, startMark, problem, endMark, note);
     }
 
     public ParsingError(ErrorCode errorCode, MarkedYAMLException cause) {
-        this.errorLevel = ParsingErrorLevel.ERROR;
-        this.errorCode = errorCode;
-        this.context = cause.getContext();
-        this.startMark = cause.getContextMark() == null ? null : new SimpleMark(cause.getContextMark());
-        this.problem = cause.getProblem();
-        this.endMark = cause.getContextMark() == null ? null : new SimpleMark(cause.getProblemMark());
-        this.note = null;
+        this(ParsingErrorLevel.ERROR, errorCode, cause.getContext(), cause.getContextMark(), cause.getProblem(), cause.getProblemMark(), null);
     }
 
     @Override

--- a/alien4cloud-core/src/main/java/alien4cloud/tosca/parser/impl/advanced/GroupPolicyParser.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/tosca/parser/impl/advanced/GroupPolicyParser.java
@@ -1,85 +1,111 @@
 package alien4cloud.tosca.parser.impl.advanced;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
 import javax.annotation.Resource;
 
-import lombok.extern.slf4j.Slf4j;
-
-import org.apache.commons.lang.StringUtils;
 import org.elasticsearch.common.collect.Maps;
 import org.springframework.stereotype.Component;
 import org.yaml.snakeyaml.nodes.MappingNode;
 import org.yaml.snakeyaml.nodes.Node;
-import org.yaml.snakeyaml.nodes.NodeTuple;
+import org.yaml.snakeyaml.nodes.ScalarNode;
 
 import alien4cloud.model.topology.AbstractPolicy;
+import alien4cloud.model.topology.GenericPolicy;
 import alien4cloud.model.topology.HaPolicy;
+import alien4cloud.tosca.parser.ParserUtils;
 import alien4cloud.tosca.parser.ParsingContextExecution;
 import alien4cloud.tosca.parser.ParsingError;
-import alien4cloud.tosca.parser.ParsingErrorLevel;
 import alien4cloud.tosca.parser.impl.ErrorCode;
 import alien4cloud.tosca.parser.impl.base.ScalarParser;
 import alien4cloud.tosca.parser.mapping.DefaultParser;
 
 @Component
-@Slf4j
 public class GroupPolicyParser extends DefaultParser<AbstractPolicy> {
 
     @Resource
     private ScalarParser scalarParser;
 
-    private static final String NAME = "name";
-
-    private static final String TYPE = "type";
+    public static final String NAME = "name";
+    public static final String TYPE = "type";
+    public static final String VALUE = "value";
+    
+    private static final Map<String,Class<? extends AbstractPolicy>> POLICY_TYPES = Maps.newLinkedHashMap();
+    
+    static {
+        POLICY_TYPES.put(HaPolicy.HA_POLICY, HaPolicy.class);
+    }
 
     @Override
     public AbstractPolicy parse(Node node, ParsingContextExecution context) {
+        if (node instanceof ScalarNode) {
+            // Spec at A.8.1.5.1 says it is a "list of names of policies"
+            // though the examples treat it as maps, and in some cases it seems the type might be specified;
+            // accept all syntaxes for now
+            Map<String, Object> nodeMap = Maps.newHashMap();
+            String name = scalarParser.parse(node, context);
+            if (POLICY_TYPES.containsKey(name)) {
+                nodeMap.put(TYPE, name);
+            } else {
+                nodeMap.put(NAME, name);
+            }
+            return buildPolicy(nodeMap, node, context);
+        }
+        
         if (!(node instanceof MappingNode)) {
             // we expect a MappingNode
             context.getParsingErrors().add(new ParsingError(ErrorCode.YAML_MAPPING_NODE_EXPECTED, null, node.getStartMark(), null, node.getEndMark(), null));
             return null;
         }
-        MappingNode mappingNode = ((MappingNode) node);
-        List<NodeTuple> children = mappingNode.getValue();
-        int tupleIdx = 0;
-        Map<String, String> nodeMap = Maps.newHashMap();
-        for (NodeTuple child : children) {
-            String key = scalarParser.parse(child.getKeyNode(), context);
-            String value = scalarParser.parse(child.getValueNode(), context);
-            if (tupleIdx == 0 && StringUtils.isEmpty(value)) {
-                // the first entry is in fact the policyName
-                nodeMap.put(NAME, key);
-            } else {
-                nodeMap.put(key, value);
+        Map<String, Object> nodeMap = ParserUtils.parseMap((MappingNode) node);
+
+        String name = (String) nodeMap.get(NAME);
+        String type = (String) nodeMap.get(TYPE);
+        if (nodeMap.size() == 1 && name==null && type==null) {
+            // short notation '<key>: <value>' where (in priority order) 
+            // - <value> is a map and <key> matches a known pre-defined type, then <value> is a map of data passed to the type
+            // - <value> matches a known pre-defined type, then <key> is taken as a name
+            // - else taken as a generic policy with name <key>, with <value> set as the map (if it's a map) or as a `value` in the map (if it's not a map)
+            Entry<String, Object> e = nodeMap.entrySet().iterator().next();
+
+            nodeMap.clear();
+            if (e.getValue() instanceof Map) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> v = (Map<String,Object>)e.getValue();
+                nodeMap.putAll(v);
+                if (POLICY_TYPES.containsKey(e.getKey())) {
+                    nodeMap.put(TYPE, e.getKey());
+                } else {
+                    nodeMap.put(NAME, e.getKey());
+                }
+            } else if (e.getValue() instanceof CharSequence) {
+                if (POLICY_TYPES.containsKey(e.getValue())) {
+                    nodeMap.put(TYPE, e.getValue().toString());
+                    nodeMap.put(NAME, e.getKey());
+                } else {
+                    nodeMap.put(NAME, e.getKey());
+                    nodeMap.put(VALUE, e.getValue().toString());
+                }
             }
         }
-        if (nodeMap.size() == 1 && !nodeMap.containsKey(NAME) && !nodeMap.containsKey(TYPE)) {
-            // short notation : 'name': 'type'
-            Entry<String, String> e = nodeMap.entrySet().iterator().next();
-            nodeMap.clear();
-            nodeMap.put(NAME, e.getKey());
-            nodeMap.put(TYPE, e.getValue());
-        }
+
         return buildPolicy(nodeMap, node, context);
     }
 
-    private AbstractPolicy buildPolicy(Map<String, String> nodeMap, Node node, ParsingContextExecution context) {
-        String type = nodeMap.get(TYPE);
+    private AbstractPolicy buildPolicy(Map<String, Object> nodeMap, Node node, ParsingContextExecution context) {
+        String type = (String) nodeMap.get(TYPE);
         AbstractPolicy result = null;
-        switch (type) {
-        case HaPolicy.HA_POLICY:
-            result = new HaPolicy();
-            break;
+        if (type!=null) {
+            switch (type) {
+            case HaPolicy.HA_POLICY:
+                result = new HaPolicy(nodeMap);
+                break;
+            }
         }
-        if (result == null) {
-            context.getParsingErrors().add(
-                    new ParsingError(ParsingErrorLevel.ERROR, ErrorCode.UNKOWN_GROUP_POLICY, null, node.getStartMark(), null, node.getEndMark(), type));
-            return null;
+        if (result==null) {
+            result = new GenericPolicy(nodeMap);
         }
-        result.setName(nodeMap.get(NAME));
         return result;
     }
 


### PR DESCRIPTION
This allows arbitrary policies to be specified in TOSCA and used through the API.

As with interfaces (#69) this won't yet be supported in the GUI, but it should help when that times come.

In this case the treatment of policies is being changed in TOSCA, but there will definitely still be a need to work with policies which aren't defined as Java types in Alien4Cloud; this code may be thrown away when that time comes (along with `HaPolicy` which is already present) although it might end up being useful, depending how that goes.

In the meantime this allows us to use A4C to configure and store arbitrary policies!
