### PR TITLE
Closed InputStream when parsing yaml

### DIFF
--- a/alien4cloud-core/src/main/java/alien4cloud/tosca/parser/YamlParser.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/tosca/parser/YamlParser.java
@@ -46,8 +46,12 @@ public abstract class YamlParser<T> {
      * @throws ParsingException In case there is a blocking issue while parsing the definition.
      */
     public ParsingResult<T> parseFile(Path yamlPath, T instance) throws ParsingException {
+        
         try {
-            return parseFile(yamlPath.toString(), yamlPath.getFileName().toString(), Files.newInputStream(yamlPath), instance);
+            InputStream inputStream = Files.newInputStream(yamlPath);
+            ParsingResult<T> res = parseFile(yamlPath.toString(), yamlPath.getFileName().toString(), inputStream, instance);
+            inputStream.close();
+            return res;
         } catch (IOException e) {
             throw new ParsingException(yamlPath.getFileName().toString(), new ParsingError(ErrorCode.MISSING_FILE, "File not found in archive.", null, null,
                     null, yamlPath.toString()));

--- a/alien4cloud-core/src/main/java/alien4cloud/tosca/parser/YamlParser.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/tosca/parser/YamlParser.java
@@ -5,6 +5,8 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.yaml.snakeyaml.composer.Composer;
 import org.yaml.snakeyaml.error.Mark;
 import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -24,6 +26,7 @@ import alien4cloud.tosca.parser.impl.base.TypeNodeParser;
  *
  * @param <T> The object instance in which to parse the object.
  */
+@Slf4j
 public abstract class YamlParser<T> {
 
     /**
@@ -46,15 +49,22 @@ public abstract class YamlParser<T> {
      * @throws ParsingException In case there is a blocking issue while parsing the definition.
      */
     public ParsingResult<T> parseFile(Path yamlPath, T instance) throws ParsingException {
-        
+        InputStream inputStream = null;
+
         try {
-            InputStream inputStream = Files.newInputStream(yamlPath);
-            ParsingResult<T> res = parseFile(yamlPath.toString(), yamlPath.getFileName().toString(), inputStream, instance);
-            inputStream.close();
-            return res;
+            inputStream = Files.newInputStream(yamlPath);
+            return parseFile(yamlPath.toString(), yamlPath.getFileName().toString(), inputStream, instance);
         } catch (IOException e) {
-            throw new ParsingException(yamlPath.getFileName().toString(), new ParsingError(ErrorCode.MISSING_FILE, "File not found in archive.", null, null,
-                    null, yamlPath.toString()));
+            throw new ParsingException(yamlPath.getFileName().toString(), new ParsingError(ErrorCode.MISSING_FILE, "File not found in archive.", null, null, null, 
+                yamlPath.toString()));
+        } finally {
+            if (inputStream != null) {
+                try {
+                    inputStream.close();
+                } catch (IOException e) {
+                    log.error("Failed to close input stream after parsing.", e);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
I have noticed that by calling `parseFile` there was a resource leak (the file to parse is opened, but never closed).
There should be no leak this way (by closing the InputStream) .