### PR TITLE
Initialize MetaProperties

### DIFF
--- a/alien4cloud-rest-api/src/main/java/alien4cloud/rest/tags/TagConfigurationController.java
+++ b/alien4cloud-rest-api/src/main/java/alien4cloud/rest/tags/TagConfigurationController.java
@@ -111,6 +111,9 @@ public class TagConfigurationController {
      private <T extends IMetaProperties> void addMetaPropertyToResources (Class<T> mpClass, IGenericSearchDAO dao, MetaPropConfiguration configuration){
     	 GetMultipleDataResult<T> result = dao.find(mpClass, null, Integer.MAX_VALUE);
     	 for (T element : result.getData()){
+    	 	 if(element.getMetaProperties() == null){
+    			 element.setMetaProperties(Maps.<String, String> newHashMap());
+    		 }
     		 element.getMetaProperties().put(configuration.getId(), configuration.getDefault());
     		 dao.save(element);
     		 log.debug("Adding meta property <{}> to a resource of type <{}> ", configuration.getName(), element.getClass());


### PR DESCRIPTION
Some resources could be created without an initialized MetaProperties Map.