### PR TITLE
Use @Slf4j annotation rather than @Log4j

### DIFF
--- a/alien4cloud-core/src/main/java/alien4cloud/tosca/ArchiveUploadService.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/tosca/ArchiveUploadService.java
@@ -6,7 +6,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import lombok.extern.log4j.Log4j;
+import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.stereotype.Component;
 
@@ -28,7 +28,7 @@ import alien4cloud.tosca.parser.ParsingResult;
 import com.google.common.collect.Maps;
 
 @Component
-@Log4j
+@Slf4j
 public class ArchiveUploadService {
 
     @Inject


### PR DESCRIPTION
Consistent with rest of the project. The difference manifests itself as:
```
Caused by: java.lang.ClassNotFoundException: org.apache.log4j.Logger
        at java.net.URLClassLoader$1.run(URLClassLoader.java:372)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:361)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.net.URLClassLoader.findClass(URLClassLoader.java:360)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:308)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        at alien4cloud.tosca.ArchiveUploadService.<clinit>(ArchiveUploadService.java:31)
```