### PR TITLE
SUPALIEN-613

### DIFF
--- a/alien4cloud-core/src/main/java/alien4cloud/configuration/InitialLoader.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/configuration/InitialLoader.java
@@ -91,6 +91,7 @@ public class InitialLoader {
         // archives must be in zip format and placed in the actual folder
         try {
             List<Path> archives = FileUtil.listFiles(rootDirectory, ".+\\.(zip|csar)");
+            Collections.sort(archives);
             for (Path archive : archives) {
                 try {
                     log.debug("Initial load of archives from <{}>.", archive.toString());


### PR DESCRIPTION
On some OS (like ubuntu) CSAR archives weren't load correctly, xtended types were tried to be load before normative types, and failed because of the missing dependence.

To fix this issue, the List<Path> has been sorted.