### PR TITLE
Upgrade Apache Commons Collections to v4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <httpclient.version>4.3.2</httpclient.version>
     <commons-cli.version>1.2</commons-cli.version>
     <commons-lang.version>3.3.2</commons-lang.version>
-    <commons-collections.version>4.0</commons-collections.version>
+    <commons-collections.version>4.1</commons-collections.version>
     <commons-compress.version>1.9</commons-compress.version>
 
     <!-- JSON and YAML Parsing -->


### PR DESCRIPTION
Version 4.0 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/