### PR TITLE
Prevent NPE when validating a Version

### DIFF
--- a/alien4cloud-core/src/main/java/alien4cloud/utils/VersionUtil.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/utils/VersionUtil.java
@@ -35,7 +35,7 @@ public final class VersionUtil {
      * @return true if it's following the defined version pattern
      */
     public static boolean isValid(String version) {
-        return VERSION_PATTERN.matcher(version).matches();
+        return version != null && VERSION_PATTERN.matcher(version).matches();
     }
 
     /**


### PR DESCRIPTION
Fixes a NPE when validating an empty property (e.g. with no default value) with type "Version".