### PR TITLE
SUPALIEN-622 use component_version

### DIFF
--- a/alien4cloud-ui/src/main/webapp/scripts/topology/services/common_node_renderer_service.js
+++ b/alien4cloud-ui/src/main/webapp/scripts/topology/services/common_node_renderer_service.js
@@ -21,9 +21,16 @@ define(function (require) {
             tooltipContent += ' <img src="images/abstract_ico.png" height="' + icoSize + '" width="' + icoSize + '"></img>';
           }
           tooltipContent += '</div>';
-          if (_.defined(element.template.properties)) {
-            if (typeof element.template.properties.version === 'string') {
-              tooltipContent += '<div>' + 'v' + element.template.properties.version + '</div>';
+          if (_.defined(element.type.derivedFrom) &&
+              $.inArray('tosca.nodes.SoftwareComponent',element.type.derivedFrom) !== -1){
+            if (_.defined(element.template.propertiesMap) &&
+                _.defined(element.template.propertiesMap.component_version)) {
+                  tooltipContent += '<div>' + 'v' + element.template.propertiesMap.component_version.value.value + '</div>';
+            }else{
+              if(_.defined(element.template.propertiesMap) &&
+                 _.defined(element.template.propertiesMap.version)){
+                   tooltipContent += '<div>' + 'v' + element.template.propertiesMap.version.value.value + '</div>';
+              }
             }
           }
           tooltipContent += '</div>';

--- a/alien4cloud-ui/src/main/webapp/scripts/topology/services/default_node_renderer_service.js
+++ b/alien4cloud-ui/src/main/webapp/scripts/topology/services/default_node_renderer_service.js
@@ -145,11 +145,17 @@ define(function(require) {
 
           // update version
           nodeGroup.select('.version').text(function() {
-            if (_.defined(nodeTemplate.propertiesMap) &&
-                _.defined(nodeTemplate.propertiesMap.version) &&
-                _.defined(nodeTemplate.propertiesMap.version.value) &&
-                _.defined(nodeTemplate.propertiesMap.version.value.value)) {
-              return 'v' + nodeTemplate.propertiesMap.version.value.value;
+            if (_.defined(node.type.derivedFrom) &&
+                $.inArray('tosca.nodes.SoftwareComponent',node.type.derivedFrom) !== -1){
+              if (_.defined(nodeTemplate.propertiesMap) &&
+                  _.defined(nodeTemplate.propertiesMap.component_version)) {
+                return 'v' + nodeTemplate.propertiesMap.component_version.value.value;
+              }else{
+                if (_.defined(nodeTemplate.propertiesMap) &&
+                    _.defined(nodeTemplate.propertiesMap.version)) {
+                  return 'v' + nodeTemplate.propertiesMap.version.value.value;
+                }
+              }
             }
           });
 


### PR DESCRIPTION
for nodes inheriting from tosca.nodes.SoftwareComponent, display 'component_version' if available, alternatively 'version' on the node and tooltip
