### PR TITLE
[Alien-1906] Change topology dependencies version in the Editor 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ alien4cloud.log
 /data/
 /target/
 /.idea/
+alien4cloud-ui/.idea/
 *.iml
 alien4cloud-rest-api/data/
 alien4cloud-security/.gitignore

--- a/alien4cloud-core/src/main/java/alien4cloud/topology/DependencyConflictDTO.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/topology/DependencyConflictDTO.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
- * Represents a dependency conflict for a source CSAR in a topology.
+ * DTO for dependency conflicts : source depends on dependency, which resolved to resolvedVersion.
  */
 @Getter
 @Setter
@@ -14,7 +14,11 @@ import lombok.Setter;
 @AllArgsConstructor
 public class DependencyConflictDTO {
 
+    /** <strong>Source</strong> is the dependency <code>archiveName:archiveVersion</code>
+     * that depends, directly or transitively, on <strong>dependency</strong>. */
     private String source;
-    private String expected;
-    private String actualVersion;
+    /** <strong>Dependency</strong> is the <code>archiveName:archiveVersion</code> that causes a dependency conflict. */
+    private String dependency;
+    /** Version of the dependency as actually resolved in the topology. */
+    private String resolvedVersion;
 }

--- a/alien4cloud-core/src/main/java/alien4cloud/topology/DependencyConflictDTO.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/topology/DependencyConflictDTO.java
@@ -1,0 +1,20 @@
+package alien4cloud.topology;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Represents a dependency conflict for a source CSAR in a topology.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DependencyConflictDTO {
+
+    private String source;
+    private String expected;
+    private String actualVersion;
+}

--- a/alien4cloud-core/src/main/java/alien4cloud/topology/TopologyDTO.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/topology/TopologyDTO.java
@@ -27,6 +27,7 @@ public class TopologyDTO extends AbstractTopologyDTO<Topology> {
     private int lastOperationIndex;
     private List<AbstractEditorOperation> operations;
     private String delegateType;
+    private List<DependencyConflictDTO> dependencyConflicts;
 
     public TopologyDTO(Topology topology, Map<String, NodeType> nodeTypes, Map<String, RelationshipType> relationshipTypes,
             Map<String, CapabilityType> capabilityTypes, Map<String, Map<String, Set<String>>> outputCapabilityProperties, Map<String, DataType> dataTypes) {

--- a/alien4cloud-core/src/main/java/alien4cloud/topology/TopologyService.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/topology/TopologyService.java
@@ -378,6 +378,9 @@ public class TopologyService {
      * @throws NotFoundException if the Type is used in the topology and not found in its context.
      */
     private void checkForMissingTypes(EditionContext context) {
+        /* TODO: Cache the result or do not use TopologyDTOBuilder
+         * because it is then called again at the end of the operation execution (EditorController.execute)
+         */
         TopologyDTO topologyDTO = topologyDTOBuilder.buildTopologyDTO(context);
         topologyDTO.getNodeTypes().forEach(throwTypeNotFound());
         topologyDTO.getRelationshipTypes().forEach(throwTypeNotFound());

--- a/alien4cloud-core/src/main/java/alien4cloud/topology/TopologyService.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/topology/TopologyService.java
@@ -362,7 +362,7 @@ public class TopologyService {
             this.checkForMissingTypes(context);
         } catch (NotFoundException e) {
             // Revert changes made to the Context then throw.
-            context.getToscaContext().updateDependencies(oldDependencies);
+            context.getToscaContext().resetDependencies(oldDependencies);
             context.getTopology().setDependencies(oldDependencies);
             throw new VersionConflictException("Changing the dependency ["+ newDependency.getName() + "] to version ["
                     + newDependency.getVersion() + "] induces missing types in the topology. Not found : [" + e.getMessage() + "].", e);

--- a/alien4cloud-core/src/main/java/org/alien4cloud/tosca/editor/processors/ChangeDependencyVersionProcessor.java
+++ b/alien4cloud-core/src/main/java/org/alien4cloud/tosca/editor/processors/ChangeDependencyVersionProcessor.java
@@ -1,8 +1,6 @@
 package org.alien4cloud.tosca.editor.processors;
 
-import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -17,10 +15,7 @@ import org.springframework.stereotype.Component;
 
 import com.google.common.collect.Sets;
 
-import alien4cloud.exception.NotFoundException;
-import alien4cloud.exception.VersionConflictException;
 import alien4cloud.topology.TopologyService;
-import alien4cloud.tosca.context.ToscaContext;
 
 /**
  * Process {@link ChangeDependencyVersionOperation}.

--- a/alien4cloud-core/src/main/java/org/alien4cloud/tosca/editor/processors/ChangeDependencyVersionProcessor.java
+++ b/alien4cloud-core/src/main/java/org/alien4cloud/tosca/editor/processors/ChangeDependencyVersionProcessor.java
@@ -47,7 +47,6 @@ public class ChangeDependencyVersionProcessor implements IEditorOperationProcess
         }
 
         CSARDependency newDependency = new CSARDependency(operation.getDependencyName(), operation.getDependencyVersion());
-        topologyService.checkDependenciesConflict(newDependency, topologyDependencies, topology);
 
         // FIXME add transitives also, if removed before
         topologyDependencies.add(newDependency);
@@ -63,7 +62,6 @@ public class ChangeDependencyVersionProcessor implements IEditorOperationProcess
         recoveryHelperService.processRecoveryOperations(topology, recoveringOperations);
 
         // TODO passing to this function the processRecoveryOperations ToscaContext should help reducing ES requests
-        // FIXME : This induce side effects as it is called AFTER the topology types has been updated
         topologyService.rebuildDependencies(topology);
     }
 

--- a/alien4cloud-core/src/main/java/org/alien4cloud/tosca/editor/processors/RecoverTopologyProcessor.java
+++ b/alien4cloud-core/src/main/java/org/alien4cloud/tosca/editor/processors/RecoverTopologyProcessor.java
@@ -41,7 +41,6 @@ public class RecoverTopologyProcessor implements IEditorOperationProcessor<Recov
         for (CSARDependency updatedDependency : AlienUtils.safe(operation.getUpdatedDependencies())) {
             ToscaContext.get().updateDependency(updatedDependency);
         }
-
         // TODO passing to this function the processRecoveryOperations ToscaContext should help reducing ES requests
         topologyService.rebuildDependencies(topology);
     }

--- a/alien4cloud-core/src/main/java/org/alien4cloud/tosca/editor/services/EditorTopologyUploadService.java
+++ b/alien4cloud-core/src/main/java/org/alien4cloud/tosca/editor/services/EditorTopologyUploadService.java
@@ -90,7 +90,7 @@ public class EditorTopologyUploadService {
         // Copy static elements from the topology
         parsedTopology.setId(currentTopology.getId());
         // Update editor tosca context
-        ToscaContext.get().updateDependencies(parsedTopology.getDependencies());
+        ToscaContext.get().resetDependencies(parsedTopology.getDependencies());
 
         // init the workflows for the topology based on the yaml
         WorkflowsBuilderService.TopologyContext topologyContext = workflowBuilderService

--- a/alien4cloud-core/src/main/java/org/alien4cloud/tosca/topology/TopologyDTOBuilder.java
+++ b/alien4cloud-core/src/main/java/org/alien4cloud/tosca/topology/TopologyDTOBuilder.java
@@ -55,7 +55,7 @@ public class TopologyDTOBuilder {
      * @return An instance of TopologyDTO (FIXME Should return an Abstract Topology DTO and renamed as not abstract)
      */
     @ToscaContextual
-    public <T extends Topology> TopologyDTO buidTopologyDTO(T topology) {
+    public <T extends Topology> TopologyDTO buildTopologyDTO(T topology) {
         TopologyDTO topologyDTO = new TopologyDTO();
         if (topology != null) {
             buildAbstractTopologyDTO(topology, topologyDTO);

--- a/alien4cloud-core/src/main/java/org/alien4cloud/tosca/topology/TopologyDTOBuilder.java
+++ b/alien4cloud-core/src/main/java/org/alien4cloud/tosca/topology/TopologyDTOBuilder.java
@@ -1,25 +1,23 @@
 package org.alien4cloud.tosca.topology;
 
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import org.alien4cloud.tosca.editor.EditionContext;
+import org.alien4cloud.tosca.model.CSARDependency;
 import org.alien4cloud.tosca.model.definitions.CapabilityDefinition;
 import org.alien4cloud.tosca.model.definitions.PropertyDefinition;
 import org.alien4cloud.tosca.model.definitions.RequirementDefinition;
 import org.alien4cloud.tosca.model.templates.AbstractTemplate;
 import org.alien4cloud.tosca.model.templates.NodeTemplate;
 import org.alien4cloud.tosca.model.templates.Topology;
-import org.alien4cloud.tosca.model.types.AbstractInheritableToscaType;
-import org.alien4cloud.tosca.model.types.CapabilityType;
-import org.alien4cloud.tosca.model.types.DataType;
-import org.alien4cloud.tosca.model.types.NodeType;
-import org.alien4cloud.tosca.model.types.PrimitiveDataType;
-import org.alien4cloud.tosca.model.types.RelationshipType;
+import org.alien4cloud.tosca.model.types.*;
 import org.springframework.stereotype.Service;
 
 import com.google.common.collect.Maps;
 
 import alien4cloud.topology.AbstractTopologyDTO;
+import alien4cloud.topology.DependencyConflictDTO;
 import alien4cloud.topology.TopologyDTO;
 import alien4cloud.tosca.context.ToscaContext;
 import alien4cloud.tosca.context.ToscaContextual;
@@ -43,8 +41,38 @@ public class TopologyDTOBuilder {
         topologyDTO.setLastOperationIndex(context.getLastOperationIndex());
         topologyDTO.setOperations(context.getOperations());
         topologyDTO.setDelegateType(context.getCsar().getDelegateType());
+
+        topologyDTO.setDependencyConflicts(getDependencyConflictDTOs(context));
+
         // FIXME add validation information
         return topologyDTO;
+    }
+
+    /**
+     * Compute a list of transitive dependency conflicts from the Context.
+     * @param context the EditionContext of the Topology being built.
+     * @return a list of dependency conflicts.
+     */
+    private List<DependencyConflictDTO> getDependencyConflictDTOs(EditionContext context) {
+        // Generate a map with all transitive dependency conflict for each dependency in the context.
+        final Set<CSARDependency> dependencies = context.getToscaContext().getDependencies();
+        Map<CSARDependency, Set<CSARDependency>> dependencyConflictMap = new HashMap<>();
+        dependencies.forEach(source -> {
+            final Set<CSARDependency> transitives =
+                    Optional.ofNullable(ToscaContext.get().getArchive(source.getName(), source.getVersion()).getDependencies())
+                            .orElse(Collections.emptySet())
+                            .stream().filter((o) -> !dependencies.contains(o)).collect(Collectors.toSet());
+            if (!transitives.isEmpty()) dependencyConflictMap.put(source, transitives);
+        });
+
+        final ArrayList<DependencyConflictDTO> dependencyConflicts = new ArrayList<>();
+        dependencyConflictMap.forEach((source, conflicts) ->
+            conflicts.forEach(conflict -> {
+                String actualVersion = dependencies.stream().filter(d -> d.getName().equals(conflict.getName())).findFirst().map(CSARDependency::getVersion).orElse("");
+                dependencyConflicts.add(new DependencyConflictDTO(source.getName(), conflict.getName() + ":" + conflict.getVersion(), actualVersion));
+            })
+        );
+        return dependencyConflicts;
     }
 
     /**

--- a/alien4cloud-core/src/test/resources/org/alien4cloud/tosca/editor/features/topology_recovery/topology_dependencies_version.feature
+++ b/alien4cloud-core/src/test/resources/org/alien4cloud/tosca/editor/features/topology_recovery/topology_dependencies_version.feature
@@ -21,13 +21,7 @@ Feature: Topology editor: Recover a topology after csar dependencies updates
       | type              | org.alien4cloud.tosca.editor.operations.ChangeDependencyVersionOperation |
       | dependencyName    | test-topo-dependencies-types                                             |
       | dependencyVersion | 0.2-SNAPSHOT                                                             |
-    Then No exception should be thrown
-    And The SPEL expression "dependencies.^[name == 'test-topo-dependencies-types'].version" should return "0.2-SNAPSHOT"
-    And The SPEL expression "nodeTemplates.size()" should return 2
-    And The SPEL expression "nodeTemplates['TestComponent']" should return "null"
-    And The SPEL expression "nodeTemplates['TestComponentSource'].properties['component_version'].value" should return "777"
-    And The SPEL expression "nodeTemplates['TestComponentSource'].relationships.size()" should return 1
-    And The SPEL expression "nodeTemplates['TestComponentSource'].relationships.values()[0].target" should return "Compute"
+    Then an exception of type "alien4cloud.exception.VersionConflictException" should be thrown
 
   Scenario: The requirement has been removed from the source node
     When I execute the operation
@@ -48,13 +42,7 @@ Feature: Topology editor: Recover a topology after csar dependencies updates
       | type              | org.alien4cloud.tosca.editor.operations.ChangeDependencyVersionOperation |
       | dependencyName    | test-topo-dependencies-types                                             |
       | dependencyVersion | 0.4-SNAPSHOT                                                             |
-    Then No exception should be thrown
-    And The SPEL expression "dependencies.^[name == 'test-topo-dependencies-types'].version" should return "0.4-SNAPSHOT"
-    And The SPEL expression "nodeTemplates.size()" should return 3
-    And The SPEL expression "nodeTemplates['TestComponent'].name" should return "TestComponent"
-    And The SPEL expression "nodeTemplates['TestComponentSource'].properties['component_version'].value" should return "777"
-    And The SPEL expression "nodeTemplates['TestComponentSource'].relationships.size()" should return 1
-    And The SPEL expression "nodeTemplates['TestComponentSource'].relationships.values()[0].target" should return "Compute"
+    Then an exception of type "alien4cloud.exception.VersionConflictException" should be thrown
 
   Scenario: The archive has a new dependency
     When I execute the operation
@@ -102,9 +90,9 @@ Feature: Topology editor: Recover a topology after csar dependencies updates
       | type              | org.alien4cloud.tosca.editor.operations.ChangeDependencyVersionOperation |
       | dependencyName    | test-topo-dependencies-trans-types                                       |
       | dependencyVersion | 0.2-SNAPSHOT                                                             |
-    Then an exception of type "alien4cloud.exception.VersionConflictException" should be thrown
+    Then No exception should be thrown
     And The SPEL expression "dependencies.^[name == 'test-topo-dependencies-types'].version" should return "0.5-SNAPSHOT"
-    And The SPEL expression "dependencies.^[name == 'test-topo-dependencies-trans-types'].version" should return "0.1-SNAPSHOT"
+    And The SPEL expression "dependencies.^[name == 'test-topo-dependencies-trans-types'].version" should return "0.2-SNAPSHOT"
 
   Scenario: The updated archive has a dependency that conflicts with one of the topology
     Given I execute the operation
@@ -119,6 +107,6 @@ Feature: Topology editor: Recover a topology after csar dependencies updates
       | type              | org.alien4cloud.tosca.editor.operations.ChangeDependencyVersionOperation |
       | dependencyName    | test-topo-dependencies-types                                             |
       | dependencyVersion | 0.5-SNAPSHOT                                                             |
-    Then an exception of type "alien4cloud.exception.VersionConflictException" should be thrown
-    And The SPEL expression "dependencies.^[name == 'test-topo-dependencies-types'].version" should return "0.6-SNAPSHOT"
-    And The SPEL expression "dependencies.^[name == 'test-topo-dependencies-trans-types'].version" should return "0.2-SNAPSHOT"
+    Then No exception should be thrown
+    And The SPEL expression "dependencies.^[name == 'test-topo-dependencies-types'].version" should return "0.5-SNAPSHOT"
+    And The SPEL expression "dependencies.^[name == 'test-topo-dependencies-trans-types'].version" should return "0.1-SNAPSHOT"

--- a/alien4cloud-rest-api/src/main/java/alien4cloud/rest/deployment/DeploymentTopologyHelper.java
+++ b/alien4cloud-rest-api/src/main/java/alien4cloud/rest/deployment/DeploymentTopologyHelper.java
@@ -15,7 +15,6 @@ import alien4cloud.model.deployment.DeploymentTopology;
 import alien4cloud.model.orchestrators.locations.LocationResourceTemplate;
 import alien4cloud.orchestrators.locations.services.ILocationResourceService;
 import alien4cloud.topology.TopologyDTO;
-import alien4cloud.topology.TopologyService;
 import alien4cloud.utils.ReflectionUtil;
 
 @Component
@@ -31,7 +30,7 @@ public class DeploymentTopologyHelper implements IDeploymentTopologyHelper {
     @Override
     public DeploymentTopologyDTO buildDeploymentTopologyDTO(DeploymentConfiguration deploymentConfiguration) {
         DeploymentTopology deploymentTopology = deploymentConfiguration.getDeploymentTopology();
-        TopologyDTO topologyDTO = topologyDTOBuilder.buidTopologyDTO(deploymentTopology);
+        TopologyDTO topologyDTO = topologyDTOBuilder.buildTopologyDTO(deploymentTopology);
         DeploymentTopologyDTO deploymentTopologyDTO = new DeploymentTopologyDTO();
         ReflectionUtil.mergeObject(topologyDTO, deploymentTopologyDTO);
         Map<String, String> locationIds = TopologyLocationUtils.getLocationIds(deploymentTopology);

--- a/alien4cloud-rest-api/src/main/java/alien4cloud/rest/runtime/RuntimeController.java
+++ b/alien4cloud-rest-api/src/main/java/alien4cloud/rest/runtime/RuntimeController.java
@@ -173,7 +173,7 @@ public class RuntimeController {
 
         Deployment deployment = deploymentService.getActiveDeploymentOrFail(environment.getId());
         DeploymentTopology deploymentTopology = deploymentRuntimeStateService.getRuntimeTopology(deployment.getId());
-        return RestResponseBuilder.<TopologyDTO> builder().data(topologyDTOBuilder.buidTopologyDTO(deploymentTopology)).build();
+        return RestResponseBuilder.<TopologyDTO> builder().data(topologyDTOBuilder.buildTopologyDTO(deploymentTopology)).build();
     }
 
     private void validateCommand(OperationExecRequest operationRequest, Topology topology) throws ConstraintFunctionalException {

--- a/alien4cloud-test-common/src/test/resources/data/csars/dependencies/scenario_4/topology.yml
+++ b/alien4cloud-test-common/src/test/resources/data/csars/dependencies/scenario_4/topology.yml
@@ -21,4 +21,4 @@ topology_template:
       requirements:
         - requires_c:
             node: node_a
-            capability: alien.tests.dependencies.capabilities.C
+            capability: alien.tests.dependencies.capabilities.CCapability

--- a/alien4cloud-test-common/src/test/resources/data/csars/dependencies/scenario_5/topology.yml
+++ b/alien4cloud-test-common/src/test/resources/data/csars/dependencies/scenario_5/topology.yml
@@ -21,4 +21,4 @@ topology_template:
       requirements:
         - requires_c:
             node: node_a
-            capability: alien.tests.dependencies.capabilities.C
+            capability: alien.tests.dependencies.capabilities.CMissing

--- a/alien4cloud-tosca/src/main/java/alien4cloud/tosca/context/ToscaContext.java
+++ b/alien4cloud-tosca/src/main/java/alien4cloud/tosca/context/ToscaContext.java
@@ -4,6 +4,7 @@ import alien4cloud.component.ICSARRepositorySearchService;
 import alien4cloud.tosca.model.ArchiveRoot;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.alien4cloud.tosca.model.CSARDependency;
@@ -87,6 +88,8 @@ public class ToscaContext {
      * Tosca context allows to cache TOSCA elements
      */
     public static class Context {
+
+        @Getter
         /** Current context dependencies. */
         private final Set<CSARDependency> dependencies;
         /** Context archives. */

--- a/alien4cloud-tosca/src/main/java/alien4cloud/tosca/context/ToscaContext.java
+++ b/alien4cloud-tosca/src/main/java/alien4cloud/tosca/context/ToscaContext.java
@@ -115,7 +115,7 @@ public class ToscaContext {
          *
          * @param newDependencies The new list of dependencies for this context.
          */
-        public void updateDependencies(Set<CSARDependency> newDependencies) {
+        public void resetDependencies(Set<CSARDependency> newDependencies) {
             Map<String, CSARDependency> dependenciesByName = Maps.newHashMap();
             for (CSARDependency dependency : dependencies) {
                 dependenciesByName.put(dependency.getName(), dependency);

--- a/alien4cloud-tosca/src/main/java/alien4cloud/tosca/parser/postprocess/ArchiveRootPostProcessor.java
+++ b/alien4cloud-tosca/src/main/java/alien4cloud/tosca/parser/postprocess/ArchiveRootPostProcessor.java
@@ -146,7 +146,7 @@ public class ArchiveRootPostProcessor implements IPostProcessor<ArchiveRoot> {
         archiveRoot.getArchive().setDependencies(mergedDependencies);
 
         // Update Tosca context with the complete dependency set
-        ToscaContext.get().updateDependencies(mergedDependencies);
+        ToscaContext.get().resetDependencies(mergedDependencies);
     }
 
     /**

--- a/alien4cloud-ui/src/main/webapp/data/languages/locale-en-us.json
+++ b/alien4cloud-ui/src/main/webapp/data/languages/locale-en-us.json
@@ -108,10 +108,10 @@
         },
         "CONFLICTS" : {
           "TITLE" : "Transitive dependency conflicts",
-          "SOURCE": "Source",
-          "DEPENDENCY": "Dependency",
-          "ACTUAL": "Actual version",
-          "MESSAGE": "Transitive dependency conflicts may cause incompatibility issues."
+          "MESSAGE_FROM": "from ",
+          "MESSAGE_VERSION": " in version ",
+          "RESOLVED": "resolved to ",
+          "WARNING": "Transitive dependency conflicts may cause incompatibility issues."
         }
       },
       "DESC_TEMPLATE" : "Topology template description",

--- a/alien4cloud-ui/src/main/webapp/data/languages/locale-en-us.json
+++ b/alien4cloud-ui/src/main/webapp/data/languages/locale-en-us.json
@@ -105,6 +105,13 @@
         "INCOMPATIBLE_VERSIONS": {
           "TITLE": "Dependency version conflict",
           "CONTENT": "The topology has already a dependency to the archive <{{archiveName}}> version <{{archiveVersion}}>. You can not use a component from the same archive with a different version. Please upgrade or downgrade the topology dependency if you want to use a different version."
+        },
+        "CONFLICTS" : {
+          "TITLE" : "Transitive dependency conflicts",
+          "SOURCE": "Source",
+          "DEPENDENCY": "Dependency",
+          "ACTUAL": "Actual version",
+          "MESSAGE": "Transitive dependency conflicts may cause incompatibility issues."
         }
       },
       "DESC_TEMPLATE" : "Topology template description",

--- a/alien4cloud-ui/src/main/webapp/data/languages/locale-fr-fr.json
+++ b/alien4cloud-ui/src/main/webapp/data/languages/locale-fr-fr.json
@@ -102,6 +102,13 @@
         "INCOMPATIBLE_VERSIONS": {
           "TITLE": "Conflit de version de dépendances",
           "CONTENT": "La topologie a déjà une dépendance vers l'archive <{{archiveName}}> version <{{archiveVersion}}>. Vous ne pouvez pas utiliser un composant provenant de cette même archive avec une version différente. Vous pouvez changer la version de la dépendance si vous souhaitez utiliser une version différente."
+        },
+        "CONFLICTS" : {
+          "TITLE" : "Conflits de dépendances transitives :",
+          "SOURCE": "Source",
+          "DEPENDENCY": "Dépendance",
+          "ACTUAL": "Version actuelle",
+          "MESSAGE": "Les conflits de dépendances transitives peuvent entrainer des incompatibilités."
         }
       },
       "DESC_TEMPLATE" : "Description du modèle",

--- a/alien4cloud-ui/src/main/webapp/data/languages/locale-fr-fr.json
+++ b/alien4cloud-ui/src/main/webapp/data/languages/locale-fr-fr.json
@@ -105,10 +105,10 @@
         },
         "CONFLICTS" : {
           "TITLE" : "Conflits de dépendances transitives :",
-          "SOURCE": "Source",
-          "DEPENDENCY": "Dépendance",
-          "ACTUAL": "Version actuelle",
-          "MESSAGE": "Les conflits de dépendances transitives peuvent entrainer des incompatibilités."
+          "MESSAGE_FROM": "depuis ",
+          "MESSAGE_VERSION": " en version ",
+          "RESOLVED": "résolu en ",
+          "WARNING": "Les conflits de dépendances transitives peuvent entrainer des incompatibilités."
         }
       },
       "DESC_TEMPLATE" : "Description du modèle",

--- a/alien4cloud-ui/src/main/webapp/data/languages/locale-ja-jp.json
+++ b/alien4cloud-ui/src/main/webapp/data/languages/locale-ja-jp.json
@@ -102,6 +102,13 @@
         "INCOMPATIBLE_VERSIONS": {
           "TITLE": "Dependency version conflict",
           "CONTENT": "The topology has already a dependency to the archive <{{archiveName}}> version <{{archiveVersion}}>. You can not use a component from the same archive with a different version. Please upgrade or downgrade the topology dependency if you want to use a different version."
+        },
+        "CONFLICTS" : {
+          "TITLE" : "Transitive dependency conflicts",
+          "MESSAGE_FROM": "from ",
+          "MESSAGE_VERSION": " in version ",
+          "RESOLVED": "resolved to ",
+          "WARNING": "Transitive dependency conflicts may cause incompatibility issues."
         }
       },
       "DESC_TEMPLATE" : "トポロジテンプレートの説明",

--- a/alien4cloud-ui/src/main/webapp/views/topology/topology_editor.html
+++ b/alien4cloud-ui/src/main/webapp/views/topology/topology_editor.html
@@ -697,25 +697,18 @@
             </tr>
           </tbody>
           </table>
-          <div ng-show="topology.dependencyConflicts">
-            <h5 style="margin-left: 10px;"><i class="fa fa-exclamation-triangle"></i>&nbsp;{{ 'APPLICATIONS.TOPOLOGY.DEPENDENCIES.CONFLICTS.TITLE' | translate }}</h5>
-            <table class="table table-hover">
-              <thead>
-              <tr>
-                <th>{{ 'APPLICATIONS.TOPOLOGY.DEPENDENCIES.CONFLICTS.SOURCE' | translate }}</th>
-                <th>{{ 'APPLICATIONS.TOPOLOGY.DEPENDENCIES.CONFLICTS.DEPENDENCY' | translate }}</th>
-                <th>{{ 'APPLICATIONS.TOPOLOGY.DEPENDENCIES.CONFLICTS.ACTUAL' | translate }}</th>
-              </tr>
-              </thead>
-              <tbody>
-                <tr ng-repeat="conflict in topology.dependencyConflicts | orderBy:'source'">
-                  <td>{{ conflict.source }}</td>
-                  <td>{{ conflict.expected }}</td>
-                  <td>{{ conflict.actualVersion }}</td>
-                </tr>
-              </tbody>
-            </table>
-            <div style="padding: 0 5px"><em>{{ 'APPLICATIONS.TOPOLOGY.DEPENDENCIES.CONFLICTS.MESSAGE' | translate }}</em></div>
+          <div style="margin: 0 10px" ng-show="topology.dependencyConflicts">
+            <h5><i class="fa fa-exclamation-triangle"></i>&nbsp;{{ 'APPLICATIONS.TOPOLOGY.DEPENDENCIES.CONFLICTS.TITLE' | translate }}</h5>
+            <div class="list-group">
+              <div class="list-group-item" ng-repeat="(key, values) in dependencies.renderedConflicts">
+                <strong class="list-group-item-heading">{{ key }}</strong>
+                <p class="list-group-item-text" ng-repeat-start="conflict in values" style="margin-left:5px" >
+                {{ 'APPLICATIONS.TOPOLOGY.DEPENDENCIES.CONFLICTS.MESSAGE_FROM' | translate }}<em>{{ conflict.source }}</em>{{ 'APPLICATIONS.TOPOLOGY.DEPENDENCIES.CONFLICTS.MESSAGE_VERSION' | translate }}<em>{{ conflict.dependency.split(':')[1] }}</em>
+                </p>
+                <strong ng-repeat-end ng-if="$last">{{ 'APPLICATIONS.TOPOLOGY.DEPENDENCIES.CONFLICTS.RESOLVED' | translate }}<em>{{ conflict.resolvedVersion }}</em></strong>
+              </div>
+            </div>
+            <p style="margin: 10px 5px"><em>{{ 'APPLICATIONS.TOPOLOGY.DEPENDENCIES.CONFLICTS.WARNING' | translate }}</em></p>
           </div>
         </div>
       </div>

--- a/alien4cloud-ui/src/main/webapp/views/topology/topology_editor.html
+++ b/alien4cloud-ui/src/main/webapp/views/topology/topology_editor.html
@@ -696,7 +696,27 @@
               <td>{{dependency.version}}</td>
             </tr>
           </tbody>
-        </table>
+          </table>
+          <div ng-show="topology.dependencyConflicts">
+            <h5 style="margin-left: 10px;"><i class="fa fa-exclamation-triangle"></i>&nbsp;{{ 'APPLICATIONS.TOPOLOGY.DEPENDENCIES.CONFLICTS.TITLE' | translate }}</h5>
+            <table class="table table-hover">
+              <thead>
+              <tr>
+                <th>{{ 'APPLICATIONS.TOPOLOGY.DEPENDENCIES.CONFLICTS.SOURCE' | translate }}</th>
+                <th>{{ 'APPLICATIONS.TOPOLOGY.DEPENDENCIES.CONFLICTS.DEPENDENCY' | translate }}</th>
+                <th>{{ 'APPLICATIONS.TOPOLOGY.DEPENDENCIES.CONFLICTS.ACTUAL' | translate }}</th>
+              </tr>
+              </thead>
+              <tbody>
+                <tr ng-repeat="conflict in topology.dependencyConflicts | orderBy:'source'">
+                  <td>{{ conflict.source }}</td>
+                  <td>{{ conflict.expected }}</td>
+                  <td>{{ conflict.actualVersion }}</td>
+                </tr>
+              </tbody>
+            </table>
+            <div style="padding: 0 5px"><em>{{ 'APPLICATIONS.TOPOLOGY.DEPENDENCIES.CONFLICTS.MESSAGE' | translate }}</em></div>
+          </div>
         </div>
       </div>
     </div>
@@ -970,7 +990,7 @@
         </li>
         <li ng-show="!displays.dependencies.active">
           <span id="topology-dependencies" ng-click="display.toggle('dependencies')">
-            <i class="fa fa-archive"></i> {{'APPLICATIONS.TOPOLOGY.DEPENDENCY' | translate}}
+            <i class="fa fa-archive"></i> {{'APPLICATIONS.TOPOLOGY.DEPENDENCY' | translate}} <i ng-show="topology.dependencyConflicts" class="fa fa-exclamation-triangle"></i>
           </span>
         </li>
         <li ng-show="!displays.inputs.active">


### PR DESCRIPTION
Accounts for ALIEN-1912, ALIEN-1925 & ALIEN-1911.

Allow changing of direct and transitives dependencies in the Editor, provided that the change doesn't create missing types.

Display a list of conflicts in the dependency panel.