### PR TITLE
Uncollapse error bloc if an uploaded CSAR contains warnings

### DIFF
--- a/alien4cloud-ui/src/main/webapp/scripts/common/directives/upload.js
+++ b/alien4cloud-ui/src/main/webapp/scripts/common/directives/upload.js
@@ -68,6 +68,7 @@ define(function (require) {
 
             // there might be warnings. display them
             if (_.defined(data.data) && _.defined(data.data.errors) && _.size(data.data.errors) >0) {
+              self.scope.uploadInfos[index].isErrorBlocCollapsed = false;
               self.scope.uploadInfos[index].errors = data.data.errors;
             }
           } else {


### PR DESCRIPTION
Hi,
When an uploaded CSAR contains some warnings, those warnings will not be clearly shown in the UI, because the upload progress bar turns into green at the end and the warning triangle does not keep attention enough.

In order to warn the user that the new component might not be fully fonctional.the upload bar shoud be in a different color like orange, or at least the warning list should be displayed.


Regards.