### PR TITLE
Tosca Parsing: support parsing of attributes on capability types

### DIFF
--- a/alien4cloud-tosca/src/main/resources/alien-dsl-2.0.0-mapping.yml
+++ b/alien4cloud-tosca/src/main/resources/alien-dsl-2.0.0-mapping.yml
@@ -408,6 +408,9 @@
   valid_source_types:
     list: validSources
     type: scalar
+  attributes:
+    map: attributes
+    type: attribute
 
 - relationship_type: org.alien4cloud.tosca.model.types.RelationshipType
   <<: *abstract_instantiable_type


### PR DESCRIPTION
This avoid a warning message on unknown tosca type.
The TOSCA model was already defined to support it.