### PR TITLE
Allow customization of the Topology serialization into YAML

### DIFF
--- a/alien4cloud-core/src/main/java/org/alien4cloud/tosca/exporter/ArchiveExportService.java
+++ b/alien4cloud-core/src/main/java/org/alien4cloud/tosca/exporter/ArchiveExportService.java
@@ -1,5 +1,11 @@
 package org.alien4cloud.tosca.exporter;
 
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.inject.Inject;
+
 import alien4cloud.application.ApplicationService;
 import alien4cloud.model.application.Application;
 import alien4cloud.security.AuthorizationUtil;
@@ -12,11 +18,6 @@ import org.alien4cloud.tosca.model.templates.Topology;
 import org.alien4cloud.tosca.model.workflow.Workflow;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.springframework.stereotype.Service;
-
-import javax.inject.Inject;
-import java.io.StringWriter;
-import java.util.HashMap;
-import java.util.Map;
 
 import static alien4cloud.utils.AlienUtils.safe;
 
@@ -51,10 +52,28 @@ public class ArchiveExportService {
      * @param csar The csar that contains archive meta-data.
      * @param topology The topology template within the archive.
      * @param generateWorkflow check if we generate the workflow
+     * @param dslVersion       the TOSCA DSL version to use
      * @return The TOSCA yaml file that describe the topology.
      */
     public String getYaml(Csar csar, Topology topology, boolean generateWorkflow, String dslVersion) {
-        Map<String, Object> velocityCtx = new HashMap<>();
+        return getYaml(csar, topology, generateWorkflow, dslVersion, null);
+    }
+
+    /**
+     * Get the yaml string out of a cloud service archive and topology.
+     *
+     * @param csar             The csar that contains archive meta-data.
+     * @param topology         The topology template within the archive.
+     * @param generateWorkflow check if we generate the workflow
+     * @param dslVersion       the TOSCA DSL version to use
+     * @param velocityCtx      allows to provide some extra configuration options to velocity
+     *
+     * @return The TOSCA yaml file that describe the topology.
+     */
+    public String getYaml(Csar csar, Topology topology, boolean generateWorkflow, String dslVersion, Map<String, Object> velocityCtx) {
+        if (velocityCtx == null) {
+            velocityCtx = new HashMap<>();
+        }
         velocityCtx.put("topology", topology);
         velocityCtx.put("template_name", csar.getName());
         velocityCtx.put("template_version", csar.getVersion());

--- a/alien4cloud-core/src/main/resources/org/alien4cloud/tosca/exporter/topology-alien_dsl_1_2_0.yml.vm
+++ b/alien4cloud-core/src/main/resources/org/alien4cloud/tosca/exporter/topology-alien_dsl_1_2_0.yml.vm
@@ -17,9 +17,7 @@ description: ${utils.renderDescription(${template_description}, "")}
 #if($utils.collectionIsNotEmpty($topology.dependencies))
 
 imports:
-#foreach($dependency in ${topology.dependencies})
-  - ${dependency.name}:${dependency.version}
-#end
+${importsUtils.generateImports($topology.dependencies)}
 #end## if
 #if($utils.hasRepositories($template_name, $template_version, $topology))
 

--- a/alien4cloud-core/src/main/resources/org/alien4cloud/tosca/exporter/topology-alien_dsl_1_3_0.yml.vm
+++ b/alien4cloud-core/src/main/resources/org/alien4cloud/tosca/exporter/topology-alien_dsl_1_3_0.yml.vm
@@ -17,9 +17,7 @@ description: ${utils.renderDescription(${template_description}, "")}
 #if($utils.collectionIsNotEmpty($topology.dependencies))
 
 imports:
-#foreach($dependency in ${topology.dependencies})
-  - ${dependency.name}:${dependency.version}
-#end
+${importsUtils.generateImports($topology.dependencies)}
 #end## if
 #if($utils.hasRepositories($template_name, $template_version, $topology))
 

--- a/alien4cloud-core/src/main/resources/org/alien4cloud/tosca/exporter/topology-alien_dsl_1_4_0.yml.vm
+++ b/alien4cloud-core/src/main/resources/org/alien4cloud/tosca/exporter/topology-alien_dsl_1_4_0.yml.vm
@@ -17,9 +17,7 @@ description: ${utils.renderDescription(${template_description}, "")}
 #if($utils.collectionIsNotEmpty($topology.dependencies))
 
 imports:
-#foreach($dependency in ${topology.dependencies})
-  - ${dependency.name}:${dependency.version}
-#end
+${importsUtils.generateImports($topology.dependencies)}
 #end## if
 #if($utils.hasRepositories($template_name, $template_version, $topology))
 

--- a/alien4cloud-core/src/main/resources/org/alien4cloud/tosca/exporter/topology-alien_dsl_2_0_0.yml.vm
+++ b/alien4cloud-core/src/main/resources/org/alien4cloud/tosca/exporter/topology-alien_dsl_2_0_0.yml.vm
@@ -30,9 +30,7 @@ description: ${utils.renderDescription(${template_description}, "")}
 #if($utils.collectionIsNotEmpty($topology.dependencies))
 
 imports:
-#foreach($dependency in ${topology.dependencies})
-  - ${dependency.name}:${dependency.version}
-#end
+${importsUtils.generateImports($topology.dependencies)}
 #end## if
 #if($utils.hasRepositories($template_name, $template_version, $topology))
 

--- a/alien4cloud-core/src/main/resources/org/alien4cloud/tosca/exporter/topology-tosca_simple_yaml_1_0.yml.vm
+++ b/alien4cloud-core/src/main/resources/org/alien4cloud/tosca/exporter/topology-tosca_simple_yaml_1_0.yml.vm
@@ -17,9 +17,7 @@ description: ${utils.renderDescription(${template_description}, "")}
 #if($utils.collectionIsNotEmpty($topology.dependencies))
 
 imports:
-#foreach($dependency in ${topology.dependencies})
-  - ${dependency.name}:${dependency.version}
-#end
+${importsUtils.generateImports($topology.dependencies)}
 #end## if
 #if($utils.hasRepositories($template_name, $template_version, $topology))
 

--- a/alien4cloud-tosca/src/main/java/alien4cloud/tosca/serializer/ToscaImportsUtils.java
+++ b/alien4cloud-tosca/src/main/java/alien4cloud/tosca/serializer/ToscaImportsUtils.java
@@ -1,0 +1,27 @@
+package alien4cloud.tosca.serializer;
+
+import java.util.Set;
+
+import org.alien4cloud.tosca.model.CSARDependency;
+
+/**
+ * A {@code ToscaImportsUtils} is a helper class that generates TOSCA imports.
+ *
+ * @author Loic Albertin
+ */
+public class ToscaImportsUtils {
+
+    public static String generateImports(Set<CSARDependency> dependencies) {
+        StringBuilder sb = new StringBuilder();
+        dependencies.forEach(d -> {
+            if (sb.length() != 0) {
+                sb.append("\n");
+            }
+            sb.append("  - ");
+            sb.append(d.getName());
+            sb.append(":");
+            sb.append(d.getVersion());
+        });
+        return sb.toString();
+    }
+}

--- a/alien4cloud-tosca/src/main/java/alien4cloud/tosca/serializer/ToscaImportsUtils.java
+++ b/alien4cloud-tosca/src/main/java/alien4cloud/tosca/serializer/ToscaImportsUtils.java
@@ -4,6 +4,8 @@ import java.util.Set;
 
 import org.alien4cloud.tosca.model.CSARDependency;
 
+import static alien4cloud.utils.AlienUtils.safe;
+
 /**
  * A {@code ToscaImportsUtils} is a helper class that generates TOSCA imports.
  *
@@ -13,7 +15,7 @@ public class ToscaImportsUtils {
 
     public static String generateImports(Set<CSARDependency> dependencies) {
         StringBuilder sb = new StringBuilder();
-        dependencies.forEach(d -> {
+        safe(dependencies).forEach(d -> {
             if (sb.length() != 0) {
                 sb.append("\n");
             }

--- a/alien4cloud-tosca/src/main/java/alien4cloud/tosca/serializer/VelocityUtil.java
+++ b/alien4cloud-tosca/src/main/java/alien4cloud/tosca/serializer/VelocityUtil.java
@@ -7,7 +7,6 @@ import java.util.Map.Entry;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
@@ -41,13 +40,20 @@ public class VelocityUtil {
         for (Entry<String, ?> contextEntry : properties.entrySet()) {
             context.put(contextEntry.getKey(), contextEntry.getValue());
         }
-        context.put("utils", new ToscaSerializerUtils());
-        context.put("propertyUtils", new ToscaPropertySerializerUtils());
+        putIfAbsent(context, "utils", new ToscaSerializerUtils());
+        putIfAbsent(context, "propertyUtils", new ToscaPropertySerializerUtils());
+        putIfAbsent(context, "importsUtils", new ToscaImportsUtils());
 
         try {
             template.merge(context, outputWriter);
         } finally {
             outputWriter.close();
+        }
+    }
+
+    private static void putIfAbsent(VelocityContext context, String key, Object value) {
+        if (!context.containsKey(key)) {
+            context.put(key, value);
         }
     }
 }


### PR DESCRIPTION
Our use case is to generate a topology with imports in another format than Alien's one.

This comes with a default generator for imports that serialize them as usual but which could be replaced through the `ArchiveExportService`.

Utilities `ToscaSerializerUtils` and `ToscaPropertySerializerUtils` could also be replaced.