### PR TITLE
Escape quotes when needed in Tosca Serialization

### DIFF
--- a/alien4cloud-tosca/src/main/java/alien4cloud/tosca/serializer/ToscaPropertySerializerUtils.java
+++ b/alien4cloud-tosca/src/main/java/alien4cloud/tosca/serializer/ToscaPropertySerializerUtils.java
@@ -41,7 +41,7 @@ public class ToscaPropertySerializerUtils {
             if (text == null) {
                 text = "";
             } else if (!VALID_YAML_PATTERN.matcher(text).matches() && !FLOAT_PATTERN.matcher(text).matches()) {
-                text = "\"" + text + "\"";
+                text = "\"" + escapeDoubleQuote(text) + "\"";
             }
             return text;
         }


### PR DESCRIPTION
If we surround a text with double quotes we should escape existing quotes within that text.