### PR TITLE
Parse operation_host on operations of NodeTypes and RelationshipTypes

### DIFF
--- a/alien4cloud-tosca/src/main/java/org/alien4cloud/tosca/model/definitions/Operation.java
+++ b/alien4cloud-tosca/src/main/java/org/alien4cloud/tosca/model/definitions/Operation.java
@@ -38,6 +38,9 @@ public class Operation {
     /** This element is not part of TOSCA but allows to specifies some portability meta-data on the operation. */
     private Map<String, AbstractPropertyValue> portability;
 
+    /** operationHost for this operation  */
+    private String operationHost;
+
     /**
      * This OPTIONAL property contains a map of one or more outputs this operation execution might generate.
      * This is not part of TOSCA, and is populated when building the plan, based on the use of the get_operation_output function in the types definition

--- a/alien4cloud-tosca/src/main/resources/alien-dsl-2.0.0-mapping.yml
+++ b/alien4cloud-tosca/src/main/resources/alien-dsl-2.0.0-mapping.yml
@@ -334,6 +334,7 @@
       list: dependencies
       type: deployment_artifact
   description: description
+  operation_host: operationHost
   inputs:
     map: inputParameters
     type: input

--- a/alien4cloud-tosca/src/test/java/alien4cloud/tosca/parser/AbstractToscaParserSimpleProfileTest.java
+++ b/alien4cloud-tosca/src/test/java/alien4cloud/tosca/parser/AbstractToscaParserSimpleProfileTest.java
@@ -182,7 +182,8 @@ public abstract class AbstractToscaParserSimpleProfileTest {
     }
 
     public static void assertNoBlocker(ParsingResult<?> parsingResult) {
-        Assert.assertFalse(countErrorByLevelAndCode(parsingResult, ParsingErrorLevel.ERROR, null) > 0);
+        Assert.assertFalse("Parsing context contains blocking errors: " +parsingResult.getContext().getParsingErrors().toString(),
+                countErrorByLevelAndCode(parsingResult, ParsingErrorLevel.ERROR, null) > 0);
     }
 
 }

--- a/alien4cloud-tosca/src/test/resources/tosca/alien_dsl_2_0_0/tosca-instantiable-type-operation-host.yml
+++ b/alien4cloud-tosca/src/test/resources/tosca/alien_dsl_2_0_0/tosca-instantiable-type-operation-host.yml
@@ -1,0 +1,42 @@
+tosca_definitions_version: alien_dsl_2_0_0
+
+metadata:
+  template_name: name
+  template_author: author
+  template_version: 1.4.0-SNAPSHOT
+
+description: This is an example of a single line description (no folding).
+
+imports:
+  - tosca-normative-types:1.0.0-ALIEN14
+
+artifact_types:
+  tosca.artifacts.Root:
+    description: root type
+  tosca.artifacts.Implementation.Bash:
+    derived_from: tosca.artifacts.Root
+    description: Script artifact for the Unix Bash shell
+    mime_type: application/x-sh
+    file_ext: [ sh, bash ]
+
+
+node_types:
+  my_company.my_types.MyAppNodeType:
+    derived_from: tosca.nodes.Root
+    interfaces:
+      Standard:
+        create:
+          description: An operation that should be executed on orchestrator host
+          operation_host: ORCHESTRATOR
+          implementation: scripts/create.sh
+
+relationship_types:
+  my_company.my_types.MyAppRelType:
+    derived_from: tosca.relationships.Root
+    interfaces:
+      Configure:
+        post_configure_target:
+          description: An operation that should be executed on the TARGET
+          operation_host: TARGET
+          implementation: scripts/pct.sh
+


### PR DESCRIPTION
**Work In Progress (discussion/feedback needed)**

## Rational

As you may know  we are working on Yorc on supporting operations executed on the orchestrator's host (see ystia/yorc#22 & ystia/yorc-a4c-plugin#14).

Currently we do it by setting a `operation_host` parameter to `ORCHESTRATOR` on a workflow step under conditions. But we think that it will be very interesting to allow a component creator to tag by himself that he is expecting an operation he implemented to be executed on the orchestrator's host

This PR currently only handles the parsing of `operation_host` but I think we can do more especially on the relationship with `operation_host` on workflows steps.

### DSL support

As you know Alien does not strictly follow the [TOSCA specification on operations & implementation](http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.2/TOSCA-Simple-Profile-YAML-v1.2.html#DEFN_ELEMENT_OPERATION_DEF)

Basically an operation should looks like

```yaml
create:
  inputs:
    myinput: { get_property: [ SELF, something] }
  implementation:
    primary: scripts/create.sh
    dependencies:
      - scripts/utils.sh
    operation_host: ORCHESTRATOR
```
In Alien the same operation currently would be

```yaml
create:
  inputs:
    myinput: { get_property: [ SELF, something] }
  implementation: scripts/create.sh
  dependencies:
    - scripts/utils.sh
```
So to keep it simple my proposal is to add support for the `operation_host` exactly the same way you did for `dependencies` in mean directly on the operation level. So with the `operation_host` it would look like

```yaml
create:
  inputs:
    myinput: { get_property: [ SELF, something] }
  implementation: scripts/create.sh
  dependencies:
    - scripts/utils.sh
  operation_host: ORCHESTRATOR
```

That what it is implemented in this PR.

### Open issues

#### Relationship between `operation_host` on operation and  `operation_host` on workflow steps

 AFAIK `operation_host` support on workflows steps in Alien is limited to steps involving a `call_operation` on a relationship to explicit if the operation should be executed on the `TARGET` or `SOURCE` side.

So the question is: **what should we do if an `operation_host`  set on a workflow step is different from the one set on an operation executed during this step ?**

I didn't find any explicit statement on this in the specification, but my point of view is that the workflow step should be preferred as it is more flexible than something defined in a type. And hopefully, we will be  able to set in the UI when designing a workflow someday.

But this implies that we should not set it "blindly" to `TARGET` or `SOURCE` but we should look if something is defined in the operation and take it into account.

What to you think?

#### Should we keep trying to guess if an operation should be executed on the orchestrator's host?

Currently in both cloudify & Yorc plugins there is an algorithm that try to guess if an operation should be executed on an existing compute or on the orchestrator's host.
Should we keep this or should we require to explicitly mark an operation with an `operation_host==ORCHESTRATOR` tag?

Thanks for your feedback