### PR TITLE
Ignore artifact resolution by returning a4c_ignore instead of null

### DIFF
--- a/alien4cloud-core/src/main/java/alien4cloud/repository/services/RepositoryService.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/repository/services/RepositoryService.java
@@ -74,6 +74,7 @@ public class RepositoryService {
 
     /**
      * Try to resolve an artifact from all configured resolver plugins and repositories
+     * This can be ignored with a4c_ignore.
      *
      * @param artifactReference reference of the artifact inside the repository
      * @param repositoryURL     the repository's URL
@@ -83,7 +84,7 @@ public class RepositoryService {
      */
     public String resolveArtifact(String artifactReference, String repositoryURL, String repositoryType, Map<String, Object> credentials) {
         if ("a4c_ignore".equals(repositoryType)) {
-            return null;
+            return "a4c_ignore";
         }
         for (IConfigurableArtifactResolver configurableArtifactResolver : registeredResolvers.values()) {
             String resolvedArtifact = configurableArtifactResolver.resolveArtifact(artifactReference, repositoryURL, repositoryType, credentials);


### PR DESCRIPTION
Referring to https://github.com/alien4cloud/alien4cloud/issues/139
allow to deploy a topology with defined repositories with type "a4c_ignore" by returning "a4c_ignore" for artifact path