### PR TITLE
Add repositories for templates artifacts

### DIFF
--- a/alien4cloud-core/src/main/java/alien4cloud/repository/services/RepositoryService.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/repository/services/RepositoryService.java
@@ -74,6 +74,7 @@ public class RepositoryService {
 
     /**
      * Try to resolve an artifact from all configured resolver plugins and repositories
+     * This can be ignored with a4c_ignore.
      *
      * @param artifactReference reference of the artifact inside the repository
      * @param repositoryURL     the repository's URL
@@ -83,7 +84,7 @@ public class RepositoryService {
      */
     public String resolveArtifact(String artifactReference, String repositoryURL, String repositoryType, Map<String, Object> credentials) {
         if ("a4c_ignore".equals(repositoryType)) {
-            return null;
+            return "a4c_ignore";
         }
         for (IConfigurableArtifactResolver configurableArtifactResolver : registeredResolvers.values()) {
             String resolvedArtifact = configurableArtifactResolver.resolveArtifact(artifactReference, repositoryURL, repositoryType, credentials);

--- a/alien4cloud-core/src/test/java/alien4cloud/tosca/serializer/ToscaSerializerUtilsTest.java
+++ b/alien4cloud-core/src/test/java/alien4cloud/tosca/serializer/ToscaSerializerUtilsTest.java
@@ -283,7 +283,7 @@ public class ToscaSerializerUtilsTest {
         deploymentArtifact.setArtifactRef("aaa/bbb.zip");
         deploymentArtifact.setArtifactType("tosca.artifacts.File");
         node.getArtifacts().put("local_war", deploymentArtifact);
-        Assert.assertFalse(ToscaSerializerUtils.hasRepositories(topology));
+        Assert.assertFalse(ToscaSerializerUtils.hasRepositories("test", "1.0", topology));
         String deploymentArtifactExport = ToscaSerializerUtils.formatArtifact(deploymentArtifact, 2);
         Assert.assertEquals("    file: aaa/bbb.zip\n    type: tosca.artifacts.File", deploymentArtifactExport);
 
@@ -298,9 +298,9 @@ public class ToscaSerializerUtilsTest {
         deploymentArtifact2.getRepositoryCredential().put("user", "my_user");
         deploymentArtifact2.getRepositoryCredential().put("token", "password");
         node.getArtifacts().put("http_war", deploymentArtifact2);
-        Assert.assertTrue(ToscaSerializerUtils.hasRepositories(topology));
+        Assert.assertTrue(ToscaSerializerUtils.hasRepositories("test", "1.0", topology));
         String deploymentArtifact2Export = ToscaSerializerUtils.formatArtifact(deploymentArtifact2, 1);
-        String repositoriesExport = ToscaSerializerUtils.formatRepositories( topology);
+        String repositoriesExport = ToscaSerializerUtils.formatRepositories("test", "1.0", topology);
         Assert.assertEquals("  file: aaa/bbb.zip\n  type: tosca.artifacts.File\n  repository: my_company", deploymentArtifact2Export);
         Assert.assertEquals("  my_company:\n    url: http://my_company.org\n    type: http\n    credential:\n      token: password\n      user: my_user",
                 repositoriesExport);
@@ -313,8 +313,8 @@ public class ToscaSerializerUtilsTest {
         deploymentArtifact3.setRepositoryURL("http://my_company.org");
         deploymentArtifact3.setArtifactRepository("maven");
         node.getArtifacts().put("http_war2", deploymentArtifact3);
-        Assert.assertTrue(ToscaSerializerUtils.hasRepositories(topology));
-        repositoriesExport = ToscaSerializerUtils.formatRepositories( topology);
+        Assert.assertTrue(ToscaSerializerUtils.hasRepositories("test", "1.0", topology));
+        repositoriesExport = ToscaSerializerUtils.formatRepositories("test", "1.0", topology);
         Assert.assertEquals(
                 "  my_company:\n    url: http://my_company.org\n    type: http\n    credential:\n      token: password\n      user: my_user\n  my_companyBis:\n    url: http://my_company.org\n    type: maven",
                 repositoriesExport);
@@ -327,8 +327,8 @@ public class ToscaSerializerUtilsTest {
         deploymentArtifact4.setRepositoryURL("http://my_company.org");
         deploymentArtifact4.setArtifactRepository("http");
         node.getArtifacts().put("http_war3", deploymentArtifact4);
-        Assert.assertTrue(ToscaSerializerUtils.hasRepositories(topology));
-        repositoriesExport = ToscaSerializerUtils.formatRepositories(topology);
+        Assert.assertTrue(ToscaSerializerUtils.hasRepositories("test", "1.0", topology));
+        repositoriesExport = ToscaSerializerUtils.formatRepositories("test", "1.0", topology);
         Assert.assertEquals(
                 "  my_company:\n    url: http://my_company.org\n    type: http\n    credential:\n      token: password\n      user: my_user\n  my_companyBis:\n    url: http://my_company.org\n    type: maven",
                 repositoriesExport);

--- a/alien4cloud-core/src/test/java/alien4cloud/tosca/serializer/ToscaSerializerUtilsTest.java
+++ b/alien4cloud-core/src/test/java/alien4cloud/tosca/serializer/ToscaSerializerUtilsTest.java
@@ -283,7 +283,7 @@ public class ToscaSerializerUtilsTest {
         deploymentArtifact.setArtifactRef("aaa/bbb.zip");
         deploymentArtifact.setArtifactType("tosca.artifacts.File");
         node.getArtifacts().put("local_war", deploymentArtifact);
-        Assert.assertFalse(ToscaSerializerUtils.hasRepositories("test", "1.0", topology));
+        Assert.assertFalse(ToscaSerializerUtils.hasRepositories(topology));
         String deploymentArtifactExport = ToscaSerializerUtils.formatArtifact(deploymentArtifact, 2);
         Assert.assertEquals("    file: aaa/bbb.zip\n    type: tosca.artifacts.File", deploymentArtifactExport);
 
@@ -298,9 +298,9 @@ public class ToscaSerializerUtilsTest {
         deploymentArtifact2.getRepositoryCredential().put("user", "my_user");
         deploymentArtifact2.getRepositoryCredential().put("token", "password");
         node.getArtifacts().put("http_war", deploymentArtifact2);
-        Assert.assertTrue(ToscaSerializerUtils.hasRepositories("test", "1.0", topology));
+        Assert.assertTrue(ToscaSerializerUtils.hasRepositories(topology));
         String deploymentArtifact2Export = ToscaSerializerUtils.formatArtifact(deploymentArtifact2, 1);
-        String repositoriesExport = ToscaSerializerUtils.formatRepositories("test", "1.0", topology);
+        String repositoriesExport = ToscaSerializerUtils.formatRepositories( topology);
         Assert.assertEquals("  file: aaa/bbb.zip\n  type: tosca.artifacts.File\n  repository: my_company", deploymentArtifact2Export);
         Assert.assertEquals("  my_company:\n    url: http://my_company.org\n    type: http\n    credential:\n      token: password\n      user: my_user",
                 repositoriesExport);
@@ -313,8 +313,8 @@ public class ToscaSerializerUtilsTest {
         deploymentArtifact3.setRepositoryURL("http://my_company.org");
         deploymentArtifact3.setArtifactRepository("maven");
         node.getArtifacts().put("http_war2", deploymentArtifact3);
-        Assert.assertTrue(ToscaSerializerUtils.hasRepositories("test", "1.0", topology));
-        repositoriesExport = ToscaSerializerUtils.formatRepositories("test", "1.0", topology);
+        Assert.assertTrue(ToscaSerializerUtils.hasRepositories(topology));
+        repositoriesExport = ToscaSerializerUtils.formatRepositories( topology);
         Assert.assertEquals(
                 "  my_company:\n    url: http://my_company.org\n    type: http\n    credential:\n      token: password\n      user: my_user\n  my_companyBis:\n    url: http://my_company.org\n    type: maven",
                 repositoriesExport);
@@ -327,8 +327,8 @@ public class ToscaSerializerUtilsTest {
         deploymentArtifact4.setRepositoryURL("http://my_company.org");
         deploymentArtifact4.setArtifactRepository("http");
         node.getArtifacts().put("http_war3", deploymentArtifact4);
-        Assert.assertTrue(ToscaSerializerUtils.hasRepositories("test", "1.0", topology));
-        repositoriesExport = ToscaSerializerUtils.formatRepositories("test", "1.0", topology);
+        Assert.assertTrue(ToscaSerializerUtils.hasRepositories(topology));
+        repositoriesExport = ToscaSerializerUtils.formatRepositories(topology);
         Assert.assertEquals(
                 "  my_company:\n    url: http://my_company.org\n    type: http\n    credential:\n      token: password\n      user: my_user\n  my_companyBis:\n    url: http://my_company.org\n    type: maven",
                 repositoriesExport);


### PR DESCRIPTION
During topology serialization, Alien checks if artifacts are internal to the serialized topology archive before adding the artifact repositories.
So, it doesn't match with artifacts included in a topology template as [here](https://github.com/ystia/yorc-a4c-plugin/blob/feature/slurm-singularity-job/tosca-samples/org/ystia/yorc/samples/job/singularity/topology/types.yaml).
In this PR, I just propose to put a warning and allow to add this repositories.