### PR TITLE
Fixing order-dependent test due to UserServiceTest

### DIFF
--- a/alien4cloud-security/src/test/java/alien4cloud/security/UserServiceTest.java
+++ b/alien4cloud-security/src/test/java/alien4cloud/security/UserServiceTest.java
@@ -8,6 +8,7 @@ import alien4cloud.security.model.User;
 import alien4cloud.security.users.UserService;
 import alien4cloud.security.users.IAlienUserDao;
 import org.junit.FixMethodOrder;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
@@ -34,7 +35,6 @@ public class UserServiceTest {
 
     @Test
     public void testEnsureAdminUserShouldNotCreateUser() throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
-        Mockito.reset(alienUserDao);
         enableEnsure();
         GetMultipleDataResult searchResult = new GetMultipleDataResult(null, null, 0, 1, 0, 1);
         Mockito.when(alienUserDao.find(Mockito.anyMap(), Mockito.eq(1))).thenReturn(searchResult);
@@ -45,12 +45,16 @@ public class UserServiceTest {
 
     @Test
     public void testEnsureAdminUserShouldCreateUser() throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException {
-        Mockito.reset(alienUserDao);
         enableEnsure();
         GetMultipleDataResult searchResult = new GetMultipleDataResult(null, null, 0, 0, 0, 0);
         Mockito.when(alienUserDao.find(Mockito.anyMap(), Mockito.eq(1))).thenReturn(searchResult);
         userService.ensureAdminUser();
 
         Mockito.verify(alienUserDao, Mockito.times(1)).save(Mockito.any(User.class));
+    }
+
+    @After
+    public void cleanup() {
+        Mockito.reset(alienUserDao);
     }
 }


### PR DESCRIPTION
When UserServiceTest.testEnsureAdminUserShouldCreateUser() runs before alien4cloud.security.LdapAuthenticationProviderTest.testLdapUserImport(), testLdapUserImport() fails. Mockito.reset() should be called once more at the end as to ensure the state is fine for later test runs. The proposed fix is to put the logic for resetting into a cleanup method for UserServiceTest, and remove duplicate calls to the reset within each test method itself.

Please let me know if you want to discuss the changes more.