### PR TITLE
Generate Sources Jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -594,6 +594,18 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven.compiler.version}</version>
         <configuration>


### PR DESCRIPTION
Allows to generate a jar that contains alien sources.
This is useful when developing a projects that depends on a4c sources.