### PR TITLE
Orchestrators lifecycle events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,8 @@ local.properties
 .loadpath
 
 # VS code IDE files
-alien4cloud-ui/.vscode/
+**/.vscode/
+**/.factorypath
 
 # External tool builders
 .externalToolBuilders/

--- a/alien4cloud-core/src/main/java/alien4cloud/orchestrators/events/AfterOrchestratorCreated.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/orchestrators/events/AfterOrchestratorCreated.java
@@ -1,0 +1,18 @@
+package alien4cloud.orchestrators.events;
+
+import alien4cloud.events.AlienEvent;
+import alien4cloud.model.orchestrators.Orchestrator;
+import lombok.Getter;
+
+/**
+ * Event dispatched after an Orchestrator has been created.
+ */
+@Getter
+public class AfterOrchestratorCreated extends AlienEvent {
+    private final Orchestrator orchestrator;
+
+    public AfterOrchestratorCreated(Object source, Orchestrator orchestrator) {
+        super(source);
+        this.orchestrator = orchestrator;
+    }
+}

--- a/alien4cloud-core/src/main/java/alien4cloud/orchestrators/events/AfterOrchestratorDeleted.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/orchestrators/events/AfterOrchestratorDeleted.java
@@ -1,0 +1,17 @@
+package alien4cloud.orchestrators.events;
+
+import alien4cloud.events.AlienEvent;
+import lombok.Getter;
+
+/**
+ * Event dispatched after an orchestrator has been deleted.
+ */
+@Getter
+public class AfterOrchestratorDeleted extends AlienEvent {
+    private final String orchestratorId;
+
+    public AfterOrchestratorDeleted(Object source, String orchestratorId) {
+        super(source);
+        this.orchestratorId = orchestratorId;
+    }
+}

--- a/alien4cloud-core/src/main/java/alien4cloud/orchestrators/events/AfterOrchestratorEnabled.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/orchestrators/events/AfterOrchestratorEnabled.java
@@ -1,0 +1,18 @@
+package alien4cloud.orchestrators.events;
+
+import alien4cloud.events.AlienEvent;
+import alien4cloud.model.orchestrators.Orchestrator;
+import lombok.Getter;
+
+/**
+ * Event dispatched after an orchestrator has been enabled.
+ */
+@Getter
+public class AfterOrchestratorEnabled extends AlienEvent {
+    private final Orchestrator orchestrator;
+
+    public AfterOrchestratorEnabled(Object source, Orchestrator orchestrator) {
+        super(source);
+        this.orchestrator = orchestrator;
+    }
+}

--- a/alien4cloud-core/src/main/java/alien4cloud/orchestrators/events/BeforeOrchestratorDeleted.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/orchestrators/events/BeforeOrchestratorDeleted.java
@@ -1,0 +1,17 @@
+package alien4cloud.orchestrators.events;
+
+import alien4cloud.events.AlienEvent;
+import lombok.Getter;
+
+/**
+ * Event dispatched before deleting an orchestrator.
+ */
+@Getter
+public class BeforeOrchestratorDeleted extends AlienEvent {
+    private final String orchestratorId;
+
+    public BeforeOrchestratorDeleted(Object source, String orchestratorId) {
+        super(source);
+        this.orchestratorId = orchestratorId;
+    }
+}

--- a/alien4cloud-core/src/main/java/alien4cloud/orchestrators/events/BeforeOrchestratorDisabled.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/orchestrators/events/BeforeOrchestratorDisabled.java
@@ -1,0 +1,18 @@
+package alien4cloud.orchestrators.events;
+
+import alien4cloud.events.AlienEvent;
+import alien4cloud.model.orchestrators.Orchestrator;
+import lombok.Getter;
+
+/**
+ * Event dispatched before disabling an orchestrator.
+ */
+@Getter
+public class BeforeOrchestratorDisabled extends AlienEvent {
+    private final Orchestrator orchestrator;
+
+    public BeforeOrchestratorDisabled(Object source, Orchestrator orchestrator) {
+        super(source);
+        this.orchestrator = orchestrator;
+    }
+}

--- a/alien4cloud-core/src/main/java/alien4cloud/orchestrators/events/OnOrchestratorConfigurationChanged.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/orchestrators/events/OnOrchestratorConfigurationChanged.java
@@ -1,0 +1,20 @@
+package alien4cloud.orchestrators.events;
+
+import alien4cloud.events.AlienEvent;
+import alien4cloud.model.orchestrators.OrchestratorConfiguration;
+import lombok.Getter;
+
+/**
+ * Event dispatched after an orchestrator configuration had changed.
+ */
+@Getter
+public class OnOrchestratorConfigurationChanged extends AlienEvent {
+    private final String orchestratorId;
+    private final OrchestratorConfiguration configuration;
+
+    public OnOrchestratorConfigurationChanged(Object source, String orchestratorId, OrchestratorConfiguration configuration) {
+        super(source);
+        this.orchestratorId = orchestratorId;
+        this.configuration = configuration;
+    }
+}

--- a/alien4cloud-core/src/main/java/alien4cloud/orchestrators/services/OrchestratorConfigurationService.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/orchestrators/services/OrchestratorConfigurationService.java
@@ -6,14 +6,16 @@ import java.util.Map;
 import javax.annotation.Resource;
 import javax.inject.Inject;
 
-import org.springframework.stereotype.Service;
-
 import com.google.common.collect.Sets;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
 
 import alien4cloud.dao.IGenericSearchDAO;
 import alien4cloud.exception.NotFoundException;
 import alien4cloud.model.orchestrators.Orchestrator;
 import alien4cloud.model.orchestrators.OrchestratorConfiguration;
+import alien4cloud.orchestrators.events.OnOrchestratorConfigurationChanged;
 import alien4cloud.orchestrators.plugin.IOrchestratorPlugin;
 import alien4cloud.orchestrators.plugin.IOrchestratorPluginFactory;
 import alien4cloud.paas.OrchestratorPluginService;
@@ -32,6 +34,9 @@ public class OrchestratorConfigurationService {
     private IGenericSearchDAO alienDAO;
     @Inject
     private OrchestratorPluginService orchestratorPluginService;
+
+    @Inject
+    private ApplicationEventPublisher publisher;
 
     /**
      * Return the type of configuration for a given orchestrator.
@@ -132,5 +137,7 @@ public class OrchestratorConfigurationService {
         }
 
         alienDAO.save(configuration);
+
+        publisher.publishEvent(new OnOrchestratorConfigurationChanged(this, id, configuration));
     }
 }

--- a/alien4cloud-core/src/main/java/alien4cloud/orchestrators/services/OrchestratorStateService.java
+++ b/alien4cloud-core/src/main/java/alien4cloud/orchestrators/services/OrchestratorStateService.java
@@ -10,17 +10,17 @@ import java.util.concurrent.Executors;
 import javax.annotation.Resource;
 import javax.inject.Inject;
 
-import alien4cloud.paas.IPaaSProviderConfiguration;
-import com.google.common.collect.Maps;
-import org.alien4cloud.tosca.model.CSARDependency;
-import org.springframework.stereotype.Component;
-
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+
+import org.alien4cloud.tosca.model.CSARDependency;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
 
 import alien4cloud.dao.IGenericSearchDAO;
 import alien4cloud.dao.model.GetMultipleDataResult;
@@ -31,11 +31,14 @@ import alien4cloud.model.deployment.Deployment;
 import alien4cloud.model.orchestrators.Orchestrator;
 import alien4cloud.model.orchestrators.OrchestratorConfiguration;
 import alien4cloud.model.orchestrators.OrchestratorState;
+import alien4cloud.orchestrators.events.AfterOrchestratorEnabled;
+import alien4cloud.orchestrators.events.BeforeOrchestratorDisabled;
 import alien4cloud.orchestrators.locations.services.LocationService;
 import alien4cloud.orchestrators.locations.services.PluginArchiveIndexer;
 import alien4cloud.orchestrators.plugin.ILocationAutoConfigurer;
 import alien4cloud.orchestrators.plugin.IOrchestratorPlugin;
 import alien4cloud.orchestrators.plugin.IOrchestratorPluginFactory;
+import alien4cloud.paas.IPaaSProviderConfiguration;
 import alien4cloud.paas.OrchestratorPluginService;
 import alien4cloud.paas.exception.PluginConfigurationException;
 import alien4cloud.utils.MapUtil;
@@ -61,6 +64,9 @@ public class OrchestratorStateService {
     private LocationService locationService;
     @Inject
     private PluginArchiveIndexer archiveIndexer;
+
+    @Inject
+    private ApplicationEventPublisher publisher;
 
     /**
      * Unload all orchestrators from JVM memory, it's typically to refresh/reload code
@@ -154,6 +160,7 @@ public class OrchestratorStateService {
     public synchronized void enable(Orchestrator orchestrator) throws PluginConfigurationException {
         if (orchestrator.getState().equals(OrchestratorState.DISABLED)) {
             load(orchestrator);
+
         } else {
             log.debug("Request to enable ignored: orchestrator {} (id: {}) is already enabled", orchestrator.getName(), orchestrator.getId());
             throw new AlreadyExistException("Orchestrator {} is already instanciated.");
@@ -235,6 +242,7 @@ public class OrchestratorStateService {
                 locationService.autoConfigure(orchestrator, (ILocationAutoConfigurer) orchestratorInstance);
             }
             indexLocationsArchives(orchestrator);
+            publisher.publishEvent(new AfterOrchestratorEnabled(this, orchestrator));
 
         } catch (IOException e) {
             // TODO: change orchestrator state ?
@@ -273,7 +281,7 @@ public class OrchestratorStateService {
                 return usages;
             }
         }
-
+        publisher.publishEvent(new BeforeOrchestratorDisabled(this, orchestrator));
         try {
             // unregister the orchestrator.
             IOrchestratorPlugin orchestratorInstance = orchestratorPluginService.unregister(orchestrator.getId());


### PR DESCRIPTION
It could be useful for plugins to react on orchestrators lifecycle events.

This PR emits events:

* After an orchestrator has been created
* After an orchestrator has been enabled
* Before an orchestrator will be disabled
* Before an orchestrator will be deleted
* After an orchestrator has been deleted