### PR TITLE
Fix typo in role COMPONENTS_MANAGER

### DIFF
--- a/alien4cloud-ui/src/main/webapp/scripts/_ref/catalog/controllers/archives/archives_list.js
+++ b/alien4cloud-ui/src/main/webapp/scripts/_ref/catalog/controllers/archives/archives_list.js
@@ -26,7 +26,7 @@ define(function (require) {
     function ($scope, $state, csarService, $translate, toaster, $uibModal, $alresource, authService, searchServiceFactory) {
 
       $scope.writeWorkspaces = [];
-      var isComponentManager = authService.hasOneRoleIn(['COMPONENT_MANAGER', 'ARCHITECT']);
+      var isComponentManager = authService.hasOneRoleIn(['COMPONENTS_MANAGER', 'ARCHITECT']);
       if (isComponentManager === true) {
         $scope.writeWorkspaces.push({id:'ALIEN_GLOBAL_WORKSPACE'});
       } else if (isComponentManager.hasOwnProperty('then')) {


### PR DESCRIPTION
A typo in the role name COMPONENTS_MANAGER prevent users with the given role to see the upload bar.